### PR TITLE
Dataset interface fixes based on 09/02 meeting

### DIFF
--- a/utils/dataset/Dataset.h
+++ b/utils/dataset/Dataset.h
@@ -27,8 +27,8 @@ struct Batch {
   LABEL_TYPE _label_type;
   uint32_t _dim;
 
-  /** 
-   * Creates a new Batch object with a size, data dimension, and data type 
+  /**
+   * Creates a new Batch object with a size, data dimension, and data type
    * If sparse, dimension can be set to 0.
    */
   Batch(uint64_t batch_size, BATCH_TYPE batch_type, LABEL_TYPE label_type,
@@ -139,7 +139,8 @@ class Dataset {
  protected:
   const uint64_t _target_batch_size, _target_batch_num_per_load;
   uint64_t _num_batches;
-  // In the future, we may need two batch arrays if we want to read in parallel while processing
+  // In the future, we may need two batch arrays if we want to read in parallel
+  // while processing
   Batch* _batches;
 };
 


### PR DESCRIPTION
Implemented these changes:
- make Dataset destructor virtual
- Comment that constructor should not load next batch set.
- assert dim not _dim in Batch constructor
- Comment that we may need two batch arrays if we want to read in parallel while processing

Confused about this one:
- Default dimension, sparse data no dimension, or lower dimension than index creates error
