### PR TITLE
Fix segfault in bolt

### DIFF
--- a/bolt/README.md
+++ b/bolt/README.md
@@ -1,7 +1,7 @@
 # Bolt Guide
 
 ### C++ Api
-To use this library you can directly link the `bolt_lib` library in cmake. There is also the `bolt` executable which takes in a config file (see below for format of config file) as an argument and will execute essentially the same code that is in the python bindings. 
+To use this library you can directly link the `bolt_lib` library in cmake. There is also the `bolt` executable which takes in a config file (see below for format of config file) as an argument and will execute the same code that is in the python bindings. The `bolt executable` will be in the directory `build/bolt/` and takes one argument which is the path to the config file, e.g. `$ ./build/bolt/bolt bolt/configs/amzn.cfg`
 
 ### Config file format 
 The format of the config files are `key = <value1>, ... , <value n>` where the values are comma separated. String values must be enclosed in single or double quotations. Lines starting with // are ignored.

--- a/bolt/benchmarks/mnist.py
+++ b/bolt/benchmarks/mnist.py
@@ -12,7 +12,7 @@ def train_sparse_output_layer(train_data, test_data):
                              range_pow=3, reservoir_size=10))
     ]
 
-    network = bolt.Network(layers=layers, input_dim=780)
+    network = bolt.Network(layers=layers, input_dim=784)
 
     network.Train(batch_size=250, train_data=train_data, test_data=test_data,
                   learning_rate=0.0001, epochs=10, rehash=3000, rebuild=10000, max_test_batches=40)
@@ -29,7 +29,7 @@ def train_sparse_hidden_layer(train_data, test_data):
         bolt.LayerConfig(dim=10, activation_function="Softmax")
     ]
 
-    network = bolt.Network(layers=layers, input_dim=780)
+    network = bolt.Network(layers=layers, input_dim=784)
 
     network.Train(batch_size=250, train_data=train_data, test_data=test_data,
                   learning_rate=0.0001, epochs=10, rehash=3000, rebuild=10000, max_test_batches=40)

--- a/bolt/bolt.cc
+++ b/bolt/bolt.cc
@@ -10,7 +10,7 @@ namespace bolt = thirdai::bolt;
 
 int main(int argc, char** argv) {
   if (argc != 2) {
-    std::cerr << "Invalid args, usage: ./slide <config file>" << std::endl;
+    std::cerr << "Invalid args, usage: ./bolt <config file>" << std::endl;
     return 1;
   }
 

--- a/bolt/configs/mnist_dense.cfg
+++ b/bolt/configs/mnist_dense.cfg
@@ -15,6 +15,6 @@ range_pow = 0, 0, 0
 batch_size = 250
 num_train = 60000
 num_test = 10000
-input_dim = 780
+input_dim = 784
 rehash = 10000000
 rebuild = 10000000

--- a/bolt/configs/mnist_sh.cfg
+++ b/bolt/configs/mnist_sh.cfg
@@ -14,6 +14,6 @@ reservoir_size = 32, 0
 range_pow = 9, 0
 
 batch_size = 250
-input_dim = 780
+input_dim = 784
 rehash = 3000
 rebuild = 10000

--- a/bolt/configs/mnist_so.cfg
+++ b/bolt/configs/mnist_so.cfg
@@ -16,6 +16,6 @@ range_pow = 0, 3
 batch_size = 250
 num_train = 60000
 num_test = 10000
-input_dim = 780
+input_dim = 784
 rehash = 500
 rebuild = 10000

--- a/utils/hashing/DWTA.cc
+++ b/utils/hashing/DWTA.cc
@@ -119,6 +119,7 @@ void DWTAHashFunction::densifyHashes(const uint32_t* hashes,
 
       next = hashes[index];
       if (count > 100) {  // Densification failure.
+        next = 0;         // Set to zero to avoid overflow on concatenation
         break;
       }
     }


### PR DESCRIPTION
Fixes #109

There were 2 bugs that were causing errors:

1. The mnist dataset indexes from 1-780 inclusive instead of 0-779. I increased the input dim in the config files/python scripts to 784 do make sure that this cannot cause any errors.
2. Because uint32_t::max was returned on densification failures in DWTA when we concatenated we exceeded the range of the hash function because the hash function assumed the hashes would be only 3 bits. 
