### PR TITLE
v0 network/layer interfaces

### DIFF
--- a/bolt/src/layers/Layer.h
+++ b/bolt/src/layers/Layer.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <BoltVector.h>
+
+namespace thirdai::bolt {
+
+class Layer {
+    public:
+        void forward(BoltVector& input, BoltVector& output);
+
+        void backpropagate(BoltVector& input, BoltVector& output);
+
+        void updateParameters(float lr, uint32_t iter, float B1, float B2, float eps);
+};
+
+}  // namespace thirdai::bolt

--- a/bolt/src/networks/Network.h
+++ b/bolt/src/networks/Network.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <dataset/src/Dataset.h>
+#include <BoltVector.h>
+
+namespace thirdai::bolt {
+
+class Network {
+    public:
+        template <typename BATCH_T>
+        void train(const dataset::InMemoryDataset<BATCH_T>& train_data);
+
+        template <typename BATCH_T>
+        void predict(const dataset::InMemoryDataset<BATCH_T>& test_data);
+    
+    private:
+        void forward(const BoltVector& input, BoltVector& output, uint32_t batch_index);
+
+        void backpropagate(const BoltVector& input, BoltVector& output, uint32_t batch_index);
+};
+
+}  // namespace thirdai::bolt

--- a/bolt/src/networks/Sequential.h
+++ b/bolt/src/networks/Sequential.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <layers/Layer.h>
+#include <Network.h>
+#include <vector>
+
+namespace thirdai::bolt {
+
+class Sequential: public Network {
+    public:
+        Sequential(std::vector<Layer>&& layers, uint32_t input_dim);
+};
+
+}  // namespace thirdai::bolt


### PR DESCRIPTION
Just looking for feedback from others!!

This is a pull request outlining what interfaces for generic Networks/Layers might work and how they might help in implementing a generic Sequential network.

General thoughts so far:

Network:
 - learning rate, and other params can possibly part of individual network constructors, as they will differ per network
 - Network::predict() should return results. Right now FullyConnectedNetwork returns a float and DLRM returns float* scores. We could maybe have the function return a vector of scores so its adaptable. 

Layer:
 - FullyConnectedNetwork needs labels for training and DLRM doesn't. Could take in labels as optional and set the default to nullptr. 

Sequential:
 - How should a layer accept inputs? Should it accept an array of layer objects or layer configs?