### PR TITLE
Remove ffast-math compiler optimization flag and change from Ofast to O3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ add_compile_options(
   $<$<CONFIG:DEBUG>:-g>
   $<$<CONFIG:DEBUG>:-fno-omit-frame-pointer>
   $<$<CONFIG:RELEASE>:-DNDEBUG>
-  $<$<CONFIG:RELEASE>:-Ofast>
-  $<$<CONFIG:RELEASE>:-ffast-math>
+  $<$<CONFIG:RELEASE>:-O3>
   $<$<CONFIG:RELEASE>:-funroll-loops>
   $<$<CONFIG:RELEASE>:-ftree-vectorize>
 )


### PR DESCRIPTION
As discussed in this [issue](https://github.com/ThirdAILabs/Universe/issues/270), we observed that the ffast-math and Ofast compiler optimization flags lead to numerical instability issues during model training. This change switches to the O3 flag which we found was stable in our testing. 

We conducted a basic experiment on the criteo DLRM dataset to understand the performance penalty of this change. We trained for only 5 epochs since we observed a segfault with the Ofast flag in the 7th epoch. We were also not able to compare these settings on the intent classification dataset because using the Ofast flag led to a segfault in the 1st epoch of training. 

| Flags      | Training Time (5 Epochs) | AUC |
| ----------- | ----------- | ------------ |
| Ofast + ffast-math      | 215 seconds       | 0.723 |
| O3   | 229 seconds        | 0.724 | 0.724
