### PR TITLE
Switch from O3 to Ofast + fno-finite-math-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,14 +38,16 @@ add_compile_options(
   $<$<CONFIG:Release>:-ftree-vectorize>
 
   $<$<CONFIG:RelWithDebInfo>:-DNDEBUG>
-  $<$<CONFIG:RelWithDebInfo>:-O3>
+  $<$<CONFIG:RelWithDebInfo>:-Ofast>
+  $<$<CONFIG:Release>:-fno-finite-math-only>
   $<$<CONFIG:RelWithDebInfo>:-funroll-loops>
   $<$<CONFIG:RelWithDebInfo>:-ftree-vectorize>
   $<$<CONFIG:RelWithDebInfo>:-g>
   $<$<CONFIG:RelWithDebInfo>:-fno-omit-frame-pointer>
 
   $<$<CONFIG:RelWithAsan>:-DNDEBUG>
-  $<$<CONFIG:RelWithAsan>:-O3>
+  $<$<CONFIG:RelWithAsan>:-Ofast>
+  $<$<CONFIG:Release>:-fno-finite-math-only>
   $<$<CONFIG:RelWithAsan>:-funroll-loops>
   $<$<CONFIG:RelWithAsan>:-ftree-vectorize>
   $<$<CONFIG:RelWithAsan>:-g>
@@ -68,12 +70,12 @@ add_compile_definitions(${FEATURE_FLAGS})
 if(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "arm64") 
   add_compile_options(
     $<$<CONFIG:RelWithAsan>:-fsanitize=address>
-    $<$<CONFIG:RelWithDebInfo>:-fsanitize=address>
+    $<$<CONFIG:DebugWithAsan>:-fsanitize=address>
   )
 
   add_link_options(
     $<$<CONFIG:RelWithAsan>:-fsanitize=address>
-    $<$<CONFIG:RelWithDebInfo>:-fsanitize=address>
+    $<$<CONFIG:DebugWithAsan>:-fsanitize=address>
   )
 endif()
 


### PR DESCRIPTION
This change switches the release build compiler optimization flags from `O3` back to `Ofast` with a flag to turn off finite-math computations which we observed created numerical instability issues during model training. The details of the performance speedup are captured in this [document](https://docs.google.com/document/d/1h7ft0oEq5RuYav9jmCrZDYtpNFQhADV0tXDL8hFkA9I/edit)