### PR TITLE
Fixing development docker container on macs

### DIFF
--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -8,19 +8,24 @@ ENV HOME /root
 SHELL ["/bin/bash", "-c"]
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y --no-install-recommends install \
+    # Install tools neccesary for building, writing, and running code
     build-essential \
     git \
     curl \
+    wget \
     mpich \
+    nano \
     libmpich-dev \
     clang-tidy-12 \
     clang \
     cmake \
     clang-format \
     gdb \
+    # Install python and pip
     python3 \
     python3-dev \
     pip \
+    # Install sudo
     && apt-get update && apt-get -y install sudo
   
 # Split this into a different RUN command for clarity, and also so if you want
@@ -38,9 +43,11 @@ RUN pip3 install \
     pandas
 
 # The exit 0 means these commands will still continue even if the install fails, 
-# this is because tensorflow (and possibly pytorch) won't work on arm64
+# this is because tensorflow, perf, and possibly pytorch won't work on arm64
 RUN pip3 install tensorflow tensorflow-datasets ; exit 0
 RUN pip3 install torch torchvision ; exit 0
+RUN apt-get install linux-tools-common linux-tools-generic linux-tools-`uname -r` ; exit 0
+
 
 RUN echo "export PYTHONPATH=/Universe/build:/Universe/benchmarks:\$PYTHONPATH" >> $HOME/.bashrc \
     ; ln -s /usr/bin/clang-tidy-12 /usr/bin/clang-tidy \


### PR DESCRIPTION
The development docker container wasn't working on m1 macs because the tensorflow installation failed