### PR TITLE
Splitting updateParameters into sparse/dense prev/current layer cases

### DIFF
--- a/bolt/src/layers/FullyConnectedLayer.h
+++ b/bolt/src/layers/FullyConnectedLayer.h
@@ -117,6 +117,8 @@ class FullyConnectedLayer {
   bool _prev_is_dense;
   bool _this_is_dense;
   // This is only used if _prev_is_dense == false and _this_is_dense == false
+  // This is a vector of unique_ptr so that the push_back in the critical
+  // region is just a pointer move and can be very fast
   std::vector<std::unique_ptr<ActiveNeuronsPair>> _active_pairs;
   // This is only used if _prev_is_dense == false
   std::vector<bool> _prev_is_active;
@@ -126,29 +128,30 @@ class FullyConnectedLayer {
   bool _force_sparse_for_inference;
 
  private:
-  inline void updateSparseSparseWeightGradients(float lr, float B1, float B2,
+  inline void updateSparseSparseWeightParameters(float lr, float B1, float B2,
+                                                 float eps,
+                                                 float B1_bias_corrected,
+                                                 float B2_bias_corrected);
+  inline void updateSparseDenseWeightParameters(float lr, float B1, float B2,
                                                 float eps,
                                                 float B1_bias_corrected,
                                                 float B2_bias_corrected);
-  inline void updateSparseDenseWeightGradients(float lr, float B1, float B2,
+  inline void updateDenseSparseWeightParameters(float lr, float B1, float B2,
+                                                float eps,
+                                                float B1_bias_corrected,
+                                                float B2_bias_corrected);
+  inline void updateDenseDenseWeightParameters(float lr, float B1, float B2,
                                                float eps,
                                                float B1_bias_corrected,
                                                float B2_bias_corrected);
-  inline void updateDenseSparseWeightGradients(float lr, float B1, float B2,
-                                               float eps,
-                                               float B1_bias_corrected,
-                                               float B2_bias_corrected);
-  inline void updateDenseDenseWeightGradients(float lr, float B1, float B2,
-                                              float eps,
-                                              float B1_bias_corrected,
-                                              float B2_bias_corrected);
-  inline void updateWeightGradient(uint64_t prev_neuron, uint64_t cur_neuron,
-                                   float lr, float B1, float B2, float eps,
+  inline void updateSingleWeightParameters(uint64_t prev_neuron,
+                                           uint64_t cur_neuron, float lr,
+                                           float B1, float B2, float eps,
+                                           float B1_bias_corrected,
+                                           float B2_bias_corrected);
+  inline void updateBiasParameters(float lr, float B1, float B2, float eps,
                                    float B1_bias_corrected,
                                    float B2_bias_corrected);
-  inline void updateBiasGradients(float lr, float B1, float B2, float eps,
-                                  float B1_bias_corrected,
-                                  float B2_bias_corrected);
   inline void cleanupWithinBatchVars();
 
   template <bool DENSE, bool PREV_DENSE>


### PR DESCRIPTION
This is a bit ugly and probably not ready to merge, so I'm definitely open to suggestions. I'm also running some final benchmarks with the new changes and will post links when they finish.

MNIST
[Original](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/10/runs/8753a11ef53246698c5081d1e068fabd)
[With changes](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/10/runs/96a924a355e24eb6a4f0460bf259086c)
No change in accuracy, possible speedup per epoch but I don't really buy it.

Amazon 670k: 
[Original](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/1/runs/6ef4fd4874ac4004a25d6468cf01baf0)
[With changes](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/1/runs/47baef7519344105aa3bd1b8ece779bc)
No change in accuracy, 10% speedup per epoch

Amazon polarity:
[Original](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/4/runs/f3af0122de2f491aa9f5dbe8801e12c2)
[With changes](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/4/runs/e903552915a24459949aceba13d5dc5c)
This is the biggest change, 1% decrease in accuracy, 10X speedup overall and 20x if you discount the dense inference

Criteo:
[Original](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/7/runs/c2202ce6a1b1445e92d1da9ce55508e4)
[With changes](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/7/runs/e36a4b4d361f407d8fb00d9d19e20c7e)
This one is weird, we get the same accuracy after 1 epoch as the original method but after that it starts decreasing. No speedup or slowdown. Maybe this is that momentum problem? Not sure. I don't think there are any sparse-sparse layers so this might be somewhere else.
Update: ran again and got the same accuracy as before, so it seems like this was a fluke.
[With changes 2](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/7/runs/8bedbb7c69da4a15a9a36edcb9ccfa69)


Birds:
[Original](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/6/runs/9f5ccd494b954faeb3674d9e648cac5f)
[With changes](http://deplo-mlflo-15qe25sw8psjr-1d20dd0c302edb1f.elb.us-east-1.amazonaws.com/#/experiments/6/runs/a651ab08b0244c05a548cbdc419a1e8b)
No change in accuracy, again slight speedup but like mnist not sure if its significant.