### PR TITLE
Add github action to run full benchmark jobs weekly

### DIFF
--- a/.github/workflows/benchmarks-suite.yml
+++ b/.github/workflows/benchmarks-suite.yml
@@ -11,7 +11,7 @@ on:
   schedule:
       # Sets the workflow to run at 1300 UTC every Saturday
       # Ref: https://jasonet.co/posts/scheduled-actions/
-      - cron: "0 13 ** 6"       
+      - cron: "0 13 * * 6"       
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Add a github actions workflow to run benchmarks on a weekly basis. 

I'm not sure of a good way to test this and I haven't verified that I got the cron syntax correct. Any suggestions would be appreciated. 