### PR TITLE
Update macOS version for test-pypi action

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-20.04, macos-10.15]
+        os: [windows-2019, ubuntu-20.04, macos-12]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
macOS-10.15 will be deprecated august 30th for GitHub Actions: https://github.com/actions/virtual-environments/issues/5583