### PR TITLE
Add install_requires so package installs clean

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,10 +140,7 @@ setup(
     ext_modules=[CMakeExtension("thirdai._thirdai")],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
-    install_requires=[
-        "numpy",
-        "typing_extensions"
-    ],
+    install_requires=["numpy", "typing_extensions"],
     extras_require={
         "test": ["pytest"],
     },


### PR DESCRIPTION
```
python3 -m pip install <..>.whl
```

should install required packages, and users should be able to start from there. Currently `numpy` and `typing_extensions` are missing. This PR adds these packages to `install_requires` in `setup.py` to make the process smoother.