### PR TITLE
[DISCUSSION] Clang tidy speedup, discussion encouraged

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -31,7 +31,7 @@ find . -type f -name "*.cc" \
 { 
   while read fname; do 
     echo $fname 
-    clang-tidy --quiet $fname
+    parallel clang-tidy --quiet $fname
     NUM_FAILED+=$?
   done
 


### PR DESCRIPTION
clang-tidy taking 30 mins to run is really annoying