### PR TITLE
Add optional requirements via setup.py for benchmarks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,13 @@ setup(
     install_requires=["numpy", "typing_extensions"],
     extras_require={
         "test": ["pytest"],
+        "benchmark": [
+            "toml",
+            "psutil",
+            "scikit-learn",
+            "mlflow",
+            "boto3",
+        ],
     },
     packages=["thirdai"]
     + ["thirdai." + p for p in find_packages(where="thirdai_python_package")],


### PR DESCRIPTION
Context: I'm working with `benchmarks` folder now (on blade) to run a few [Gradient Compression](https://proceedings.mlr.press/v97/spring19a.html) experiments on bigger datasets, after going through the routine of missing packages while attempting to run benchmarks, figured I can hook this into `setup.py`. I will have to repeat this for multiple nodes when I make copies while working with blade. Towards this, I am proposing to setup this python setuptools based convenient, and quite standard way of doing things.

For my locally built wheels, the issued command looks as follows:

```bash
python3 -m pip install "dist/thirdai-0.1.7-cp39-cp39-macosx_12_0_arm64.whl[benchmark]"
```

When installing from PyPI, the above is expected to turn to:

```bash
python3 -m pip install "thirdai[benchmark]"
```


I should probably document the above instructions somewhere for other developers reference as well, will be happy to if one of the established developers can point the correct location. The `boto3`, `mlflow` requirements are even more optional, but I figure hard-disk storage can be expected to be cheap. 

cc @sidjain3ai 