### PR TITLE
Rename num_numerical_features to max_num_numerical_features

### DIFF
--- a/benchmarks/bolt_benchmarks/configs/criteo_dlrm.txt
+++ b/benchmarks/bolt_benchmarks/configs/criteo_dlrm.txt
@@ -16,7 +16,7 @@ format = "click"
 type_list = ["train_data", "train_tokens", "train_labels"]
 path = "criteo-small/train_shuf.txt"
 batch_size = 256
-num_numerical_features = 15
+max_num_numerical_features = 15
 max_categorical_features = 23
 delimiter = " "
 
@@ -25,7 +25,7 @@ format = "click"
 type_list = ["test_data", "test_tokens", "test_labels"]
 path = "criteo-small/test_shuf.txt"
 batch_size = 256
-num_numerical_features = 15
+max_num_numerical_features = 15
 max_categorical_features = 23
 delimiter = " "
 

--- a/benchmarks/bolt_benchmarks/run_bolt_experiment.py
+++ b/benchmarks/bolt_benchmarks/run_bolt_experiment.py
@@ -287,7 +287,9 @@ def load_click_through_dataset(dataset_config):
     return dataset.load_click_through_dataset(
         filename=dataset_path,
         batch_size=config_get(dataset_config, "batch_size"),
-        num_numerical_features=config_get(dataset_config, "num_numerical_features"),
+        max_num_numerical_features=config_get(
+            dataset_config, "max_num_numerical_features"
+        ),
         max_categorical_features=config_get(dataset_config, "max_categorical_features"),
         delimiter=config_get(dataset_config, "delimiter"),
     )


### PR DESCRIPTION
Make benchmark experiment for criteo work out of the box.

Making  @tharunkr24's [direction for a fix](https://thirdaiworkspace.slack.com/archives/C02BR2J5EAC/p1660305098121289) more out of the box.



<details>
<summary> Before (click to expand) </summary>

```
(env) jerin@ubuntu6:~/code/Universe/benchmarks/bolt_benchmarks$ python3 run_bolt_experiment.py --disable_mlflow configs/criteo_dlrm.txt

======================= Bolt Model =======================
input_1 (Input) : dim=15
token_input_1 (TokenInput)
input_1 -> fc_1 (FullyConnected): dim=1000, sparsity=0.2, act_func=ReLU
token_input_1 -> embedding_1: (Embedding): num_embedding_lookups=8, lookup_size=16, log_embedding_block_size=10
fc_1 -> fc_2 (FullyConnected): dim=100, sparsity=1, act_func=ReLU
(fc_2, embedding_1) -> concat_1 (Concatenate)
concat_1 -> fc_3 (FullyConnected): dim=1000, sparsity=0.2, act_func=ReLU
fc_3 -> fc_4 (FullyConnected): dim=2, sparsity=1, act_func=Softmax
============================================================
Traceback (most recent call last):
  File "run_bolt_experiment.py", line 393, in <module>
    main()
  File "run_bolt_experiment.py", line 25, in main
    datasets = load_all_datasets(config)
  File "run_bolt_experiment.py", line 107, in load_all_datasets
    loaded_datasets = load_click_through_dataset(single_dataset_config)
  File "run_bolt_experiment.py", line 287, in load_click_through_dataset
    return dataset.load_click_through_dataset(
TypeError: load_click_through_dataset(): incompatible function arguments. The following argument types are supported:
    1. (filename: str, batch_size: int, max_num_numerical_features: int, max_categorical_features: int, delimiter: str = '\t') -> Tuple[thirdai::dataset::InMemoryDataset<thirdai::bolt::BoltBatch>, thirdai::dataset::InMemoryDataset<thirdai::dataset::BoltTokenBatch>, thirdai::dataset::InMemoryDataset<thirdai::bolt::BoltBatch>]

Invoked with: kwargs: filename='/share/data/criteo-small/train_shuf.txt', batch_size=256, num_numerical_features=15, max_categorical_features=23, delimiter=' '
```
</details>

<details>
<summary> After (click to expand) </summary>

```
(env) jerin@ubuntu6:~/code/Universe/benchmarks/bolt_benchmarks$ python3 run_bolt_experiment.py --disable_mlflow configs/criteo_dlrm.txt

======================= Bolt Model =======================
input_1 (Input) : dim=15
token_input_1 (TokenInput)
input_1 -> fc_1 (FullyConnected): dim=1000, sparsity=0.2, act_func=ReLU
token_input_1 -> embedding_1: (Embedding): num_embedding_lookups=8, lookup_size=16, log_embedding_block_size=10
fc_1 -> fc_2 (FullyConnected): dim=100, sparsity=1, act_func=ReLU
(fc_2, embedding_1) -> concat_1 (Concatenate)
concat_1 -> fc_3 (FullyConnected): dim=1000, sparsity=0.2, act_func=ReLU
fc_3 -> fc_4 (FullyConnected): dim=2, sparsity=1, act_func=Softmax
============================================================
Loaded 800000 vectors from '/share/data/criteo-small/train_shuf.txt' in 2 seconds
Loaded 200000 vectors from '/share/data/criteo-small/test_shuf.txt' in 0 seconds

Epoch 1:

```

</details>