### PR TITLE
Remove unused variable in text preprocessing 

### DIFF
--- a/dataset/src/encodings/text/TextEncodingUtils.h
+++ b/dataset/src/encodings/text/TextEncodingUtils.h
@@ -194,8 +194,6 @@ class TextEncodingUtils {
 
     std::sort(indices.begin(), indices.end());
 
-    std::vector<uint32_t> new_indices;
-
     /**
      * If current index is the same as the next index, keep accumulating
      * summed_val. Otherwise, add sparse feature at the current index with the


### PR DESCRIPTION
This is a minor one line change. There is a `new_indices`, which on search 
appears to be unused. Surprised static-analysis did not pick this one up.

https://github.com/ThirdAILabs/Universe/search?q=new_indices shows only 
one occurrence. 