### PR TITLE
Make UniversalHash deterministic for a given seed

### DIFF
--- a/hashing/src/UniversalHash.cc
+++ b/hashing/src/UniversalHash.cc
@@ -6,12 +6,9 @@
 
 namespace thirdai::hashing {
 
-UniversalHash::UniversalHash(uint32_t seed) {
+UniversalHash::UniversalHash(uint32_t seed) : _seed(seed) {
   // We can decide to pass in a generator instead, if needed.
-  _seed = seed;
-  srand(seed);
-  std::random_device rd;
-  std::mt19937_64 gen(rd());
+  std::mt19937_64 gen(_seed);
   std::uniform_int_distribution<uint64_t> dis;
   for (auto& i : T) {
     for (auto& j : i) {


### PR DESCRIPTION
Earlier implementation of UniversalHash does not use the seed provided
and output is non-deterministic. If the user has provided a seed, then
hash functions of the same seed should give the same hashes for the
same elements.

Earlier,

```
UniversalHash h1(seed), h2(seed);

h1.getHash(some_value) != h2.getHash(some_value)
```

which is unwanted behavior.

Now, the hash functions return the same values. 