### PR TITLE
Disable omp pragma in DragonVector::sketch

### DIFF
--- a/compression/src/DragonVector.cc
+++ b/compression/src/DragonVector.cc
@@ -65,8 +65,8 @@ template <class T>
 void DragonVector<T>::sketch(const T* values, T threshold, uint32_t size,
                              uint32_t sketch_size) {
   UniversalHash hash_function = UniversalHash(_seed_for_hashing);
-  // TODO: MSVC complains about sharing values in the below block. Disabling
-  // short term to get builds green.
+  // TODO(TSK-567): MSVC complains about sharing values in the below block.
+  // Disabling short term to get builds green.
   //
   //     D:\a\Universe\Universe\compression\src\DragonVector.cc(68,9): error
   //     C3028: 'thirdai::compression::DragonVector<float>::_values': only a


### PR DESCRIPTION
This is part of a series of commits which gets Python wheel builds back to green. In this case, MSVC OpenMP complains about const variable marked as shared among OMP threads, leading to an error. This change temporarily comments out the code which causes this making sketching not OMP parallel.

```
       D:\a\Universe\Universe\compression\src\DragonVector.cc(68,9): error
       C3028: 'thirdai::compression::DragonVector<float>::_values': only a
       variable or static data member can be used in a data-sharing clause
       [D:\a\Universe\Universe\build\_thirdai.vcxproj]
```

cc @shubh3ai.