### PR TITLE
Relax GH actions for wheel builds

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -4,7 +4,7 @@ name: Upload to Test Pypi
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
 concurrency: 
   group: testpypi-${{ github.head_ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Run on pushes and releases. The actual upload will only happen on a 
 # release.
@@ -26,6 +26,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-2019, ubuntu-20.04, macos-12]
 


### PR DESCRIPTION
Earlier concurrent jobs would cancel other jobs, which is wasteful. Also, fail-fast:true being default cancels other workflows if any of Windows / Ubuntu / MacOS fails. This is perhaps an attempt to save CI minutes, but is pointless now that these run only on main and we may re-run only failed jobs.