### PR TITLE
Build only _thirdai (no tests/all) via setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,17 @@ class CMakeBuild(build_ext):
             # not used on MSVC, but no harm
             "-DCMAKE_BUILD_TYPE={}".format(build_mode),
         ]
+
+        # To build the wheel, we don't need to make "all" targets. We just need
+        # what is required to be packaged with python.  The pybind11 target in
+        # CMakeLists.txt is defined as _thirdai, which is what is shipped with
+        # the built wheel. Since setup.py is for use in packaging the wheel, we
+        # pass this specific target to cmake args to avoid having to compile
+        # tests and other potential libraries/executables created.
+        #
+        # Equivalent to calling `make _thirdai`.
         build_args = ["-t", "_thirdai"]
+
         # Adding CMake arguments set as environment variable
         # (needed e.g. to build for ARM OSx on conda-forge)
         if "CMAKE_ARGS" in os.environ:


### PR DESCRIPTION
There is no need to wait for all the test executables to build while the
package is being built via setup.py. From what I see locally, there is a long
waiting for the test executables to build for a change that's only related to
python (no testing, >2 min).  Towards simplifying the situation, the bare
minimum requirement (i.e _thirdai, which is the pybind target) alone is
configured to be built via setup.py (while the wheel builds are in play).

The time gain from not having to build a lot of executables should also reflect
across CI and wheel builds.