### PR TITLE
optimizer initialization for getinputgradients method

### DIFF
--- a/bolt/python_tests/test_explainability.py
+++ b/bolt/python_tests/test_explainability.py
@@ -1,29 +1,22 @@
 from thirdai import bolt, dataset
 import pytest
 import numpy as np
-from utils import gen_numpy_training_data
+from utils import gen_numpy_training_data, get_simple_dag_model
 
 pytestmark = [pytest.mark.unit]
+n_classes = 100
+batch_size = 100
 
 
-def test_get_input_gradients():
-    n_classes = 100
-    batch_size = 100
-    input_layer = bolt.graph.Input(dim=n_classes)
-    hidden_layer = bolt.graph.FullyConnected(dim=200, activation="relu")(input_layer)
-    output_layer = bolt.graph.FullyConnected(dim=n_classes, activation="softmax")(
-        hidden_layer
+def get_trained_model(n_samples):
+    model = get_simple_dag_model(
+        input_dim=n_classes,
+        hidden_layer_dim=200,
+        hidden_layer_sparsity=1,
+        output_dim=n_classes,
     )
 
-    model = bolt.graph.Model(inputs=[input_layer], output=output_layer)
-    model.compile(bolt.CategoricalCrossEntropyLoss())
-
-    train_x, train_y = gen_numpy_training_data(n_classes=n_classes, n_samples=2000)
-
-    test_x_np, test_y_np = gen_numpy_training_data(
-        n_classes=n_classes, convert_to_bolt_dataset=False
-    )
-    test_x = dataset.from_numpy(test_x_np, batch_size=batch_size)
+    train_x, train_y = gen_numpy_training_data(n_classes=n_classes, n_samples=n_samples)
 
     train_cfg = bolt.graph.TrainConfig.make(learning_rate=0.001, epochs=10)
 
@@ -32,6 +25,17 @@ def test_get_input_gradients():
         train_y,
         train_cfg,
     )
+
+    return model
+
+
+def test_get_input_gradients():
+    model = get_trained_model(n_samples=2000)
+
+    test_x_np, test_y_np = gen_numpy_training_data(
+        n_classes=n_classes, convert_to_bolt_dataset=False
+    )
+    test_x = dataset.from_numpy(test_x_np, batch_size=batch_size)
 
     correct_explainations = 0
     total = 0
@@ -47,3 +51,24 @@ def test_get_input_gradients():
             total += 1
 
     assert correct_explainations >= 0.8 * total
+
+
+def test_get_input_gradients_load_and_save():
+    model = get_trained_model(n_samples=200)
+
+    test_x_np, _ = gen_numpy_training_data(
+        n_classes=n_classes, convert_to_bolt_dataset=False
+    )
+    test_x = dataset.from_numpy(test_x_np, batch_size=batch_size)
+
+    model_saved_file = "saved_model"
+
+    model.save(model_saved_file)
+
+    loaded_model = bolt.graph.Model.load(model_saved_file)
+
+    for batch_idx in range(len(test_x)):
+        for vec_idx in range(len(test_x[batch_idx])):
+            explain = model.explain_prediction([test_x[batch_idx][vec_idx]])
+            load_explain = loaded_model.explain_prediction([test_x[batch_idx][vec_idx]])
+            assert explain == load_explain

--- a/bolt/src/graph/Graph.cc
+++ b/bolt/src/graph/Graph.cc
@@ -694,6 +694,11 @@ void BoltGraph::verifyCanGetInputGradientSingle(
         "The sparse output dimension should be atleast 2 to call "
         "getSecondHighestActivationId.");
   }
+
+  for (auto& node : _nodes) {
+    node->initOptimizer();
+  }
+
   verifyInputForGraph(single_input_gradients_context);
 }
 


### PR DESCRIPTION
When we save the model we are not saving the optimiser states , so when we load the model and call getinputgradients which internally calls backprop, fails an assertion causing to segfault, hence initialise as we do for train method.