### PR TITLE
Allow a (local) build-identifier to be supplied by envvar

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,6 +146,9 @@ class CMakeBuild(build_ext):
 version = None
 with open("thirdai.version") as version_file:
     version = version_file.read().strip()
+    suffix = os.environ.get("THIRDAI_BUILD_IDENTIFIER", None)
+    if suffix:
+        version = "{}+{}".format(version, suffix)
 
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#local-version-identifiers

Easier to have something like:

```bash
SHA=$(git rev-parse --short HEAD)
VERSION=$(cat thirdai.version)

THIRDAI_BUILD_IDENTIFIER=$SHA python3 setup.py bdist_wheel
python3 -m pip install dist/thirdai-$VERSION+$SHA.<>.whl

```

Harmless with the rest of the source, minor convenience otherwise.
