### PR TITLE
Restore incremental model.train() behaviour

### DIFF
--- a/bolt/src/graph/Graph.cc
+++ b/bolt/src/graph/Graph.cc
@@ -89,20 +89,22 @@ MetricData BoltGraph::train(
   CallbackList callbacks = train_config.getCallbacks();
   callbacks.onTrainBegin(*this, train_state);
 
-  // There are a few cases of epoch calculation to handle here, which is not
-  // obvious reading the code here locally. We want _epoch to be the single
-  // source of truth for all cases.
-  //
-  // 1. Fresh training. The constructor would have set _epoch to 0.
-  // 2. There is currently the option for the client to incrementally train,
-  //    similar to an undocumented behaviour in Keras.
-  //
-  //    https://github.com/keras-team/keras/issues/4446
-  //
-  //    We do not want this behaviour broken to avoid surprises.
-  //
-  // 3. TODO(jerin): We have loaded a checkpoint and want to resume training. We
-  //    have epoch loaded from cereal archive here.
+  /*
+   * There are a few cases of epoch calculation to handle here, which is not
+   * obvious reading the code here locally. We want _epoch to be the single
+   * source of truth for all cases.
+   *
+   * 1. Fresh training. The constructor would have set _epoch to 0.
+   * 2. There is currently the option for the client to incrementally train,
+   *    similar to an undocumented behaviour in Keras.
+   *
+   *    https://github.com/keras-team/keras/issues/4446
+   *
+   *    We do not want this behaviour broken to avoid surprises.
+   *
+   * 3. TODO(jerin): We have loaded a checkpoint and want to resume training. We
+   *    have epoch loaded from cereal archive here.
+   */
 
   // Treat the supplied epochs as additional epochs. Use this to generate the
   // total num_epochs. This way _epoch indicates how many passes have been made


### PR DESCRIPTION
This restores previous behaviour of `_epoch` (which continues training for the number of additional epochs to be trained). There's also a bug of new variable `_epoch` shadowing the class variable introduced by accident, which this PR solves. 

`_epoch` now always stores the number of passes through the any datasets. For example if fine-tuning for `10` epochs after training for `100` epochs, _epoch would have values from `100 - 109`. On incrementally training, this variable will track exactly what epoch the model is training on. 

We should in the future consolidate `TrainState.epoch`, `TrainState.batch_cnt`, which is also a source of confusion (`_batch_cnt` used to track updates - this got renamed to `_updates` in #846. `TrainState.batch_cnt` currently tracks `batch_id` within an epoch, inconsistent with former `_batch_cnt`).

To avoid future errors, a big block of comment is added listing possible uses. 