### PR TITLE
Downgrade mac os CI version

### DIFF
--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-20.04, macos-12]
+        os: [windows-2019, ubuntu-20.04, macos-11]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Our Mac OS build wheel action is failing: 
https://github.com/ThirdAILabs/Universe/actions/runs/3186564544/jobs/5197662721#step:13:549

Possible fix (from gh issue) is to downgrade to macOS-11
https://github.com/actions/runner-images/issues/6350