### PR TITLE
No Mac Os Wheel And Concurrency Fix

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -2,8 +2,8 @@ name: Run Python Benchmark Sanity Check
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: benchmarktest-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
   
 # Controls when the workflow will run

--- a/.github/workflows/benchmarks-suite.yml
+++ b/.github/workflows/benchmarks-suite.yml
@@ -2,8 +2,8 @@ name: Run Python BOLT Benchmarks
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: benchmarksuite-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
   
 # Controls when the workflow will run

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -2,8 +2,8 @@ name: Check Formatting
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: format-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Controls when the workflow will run

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -2,8 +2,8 @@ name: Run C++ Tests
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: cpptest-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Controls when the workflow will run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,8 @@ name: Lint C++ Code
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: lint-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Controls when the workflow will run

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -2,8 +2,8 @@ name: Run Python Tests
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: pytest-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
   
 # Controls when the workflow will run

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -2,8 +2,8 @@ name: Sync Python Docs
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: syncpythondocs-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 # Controls when the workflow will run

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -2,9 +2,9 @@ name: Upload to Test Pypi
 
 # Kills old jobs from the same pr if we push a new commit
 # See https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
-concurrency: 
-  group: testpypi-${{ github.head_ref }}
-  cancel-in-progress: false
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Run on pushes and releases. The actual upload will only happen on a 
 # release.
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, ubuntu-20.04, macos-12]
+        os: [windows-2019, ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Small fix to make canceling concurrent jobs work correctly (works on all events, not just PRs now):
`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
Also, removed the macos wheel for release to work