### PR TITLE
Disable mlflow for benchmarking actions

### DIFF
--- a/bin/benchmark_bolt.py
+++ b/bin/benchmark_bolt.py
@@ -39,7 +39,7 @@ def main():
         os.path.dirname(os.path.realpath(__file__))
         if (
             subprocess.call(
-                f"python3 benchmarks/bolt.py --disable_upload_artifacts --run_name {run_name}  {config} ",
+                f"python3 benchmarks/bolt.py --disable_upload_artifacts --disable_mlflow  {config} ",
                 shell=True,
                 cwd=universe_dir,
             )


### PR DESCRIPTION
This change temporarily disables our mlflow option for benchmarking tests since the mlflow is currently offline. 