### PR TITLE
Do not truncate logfile on relaunch

### DIFF
--- a/utils/Logging.cc
+++ b/utils/Logging.cc
@@ -34,7 +34,7 @@ void setup(bool log_to_stderr /*= DEFAULT_LOG_TO_STDERR*/,
     }
 
     if (!path.empty()) {
-      auto file_sink = std::make_shared<FileSink>(path, true);
+      auto file_sink = std::make_shared<FileSink>(path, /*truncate=*/false);
       sinks.push_back(file_sink);
     }
 


### PR DESCRIPTION
This ensures the logs are appended to a file. Useful in the case of resuming training after interrupting the program, so the loss etc stays in the file. In the event fresh log-files are needed, there is always the option of supplying a new file.

<details> <summary> Log output example (Click to expand) </summary> 

```
$ python3 -m forge.run.mnist --log-file workspace/mnist/mnist.log --workspace workspace/mnist --save-prefix workspace/mnist/ --log-to-stderr --test-metrics categorical_accuracy

$ cat workspace/mnist/mnist.log  | less
[2022-11-11T05:43:21] [info] | thirdai 0.5.1+868ab7fc
[2022-11-11T05:43:21] [info] | args | Namespace(hidden_dim=10000, hidden_sparsity=0.05, learning_rate=0.0001, log_file='workspace/mnist/mnist.log', log_level='info', log_loss_frequency=32, log_to_stderr=True, num_epochs=10, num_hidden=1, rebuild_hash_tables=100000, reconstruct_hash_functions=10000, resume=False, save_best_per='', save_frequency=32, save_prefix='workspace/mnist/', test_metrics=['categorical_accuracy'], train_metrics=['mean_squared_error'], validate_frequency=32, workspace='workspace/mnist')
[2022-11-11T05:43:21] [info] | env  | {'load_before_experiment': 0.27, 'platform': 'Linux-5.4.0-126-generic-x86_64-with-glibc2.29', 'platform_version': '#142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022', 'platform_release': '5.4.0-126-generic', 'architecture': 'x86_64', 'processor': 'x86_64', 'hostname': 'ubuntu9', 'ram_gb': 252, 'num_cores': 48, 'thirdai.version': '0.5.1+868ab7fc'}
[2022-11-11T05:43:21] [info] | Loaded 60000 vectors from 'workspace/mnist/mnist' in 0 seconds.
[2022-11-11T05:43:21] [info] | Loaded 10000 vectors from 'workspace/mnist/mnist.t' in 0 seconds.
[2022-11-11T05:43:22] [info] | 
======================= Bolt Model =======================
input_1 (Input): dim=784
input_1 -> fc_1 (FullyConnected): dim=10000, sparsity=0.05, act_func=ReLU
fc_1 -> fc_2 (FullyConnected): dim=10, sparsity=1, act_func=Softmax
============================================================

[2022-11-11T05:43:22] [info] | train | epoch 0 | updates 1 | {mean_squared_error: 1.46834}
[2022-11-11T05:43:22] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:43:23] [info] | predict | epoch 0 | updates 1 | {categorical_accuracy: 0.2321} | batches 40 | time 1182ms
[2022-11-11T05:43:24] [info] | train | epoch 0 | updates 32 | {mean_squared_error: 0.567967}
[2022-11-11T05:43:24] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:43:25] [info] | predict | epoch 0 | updates 32 | {categorical_accuracy: 0.831} | batches 40 | time 1286ms
[2022-11-11T05:43:26] [info] | train | epoch 0 | updates 64 | {mean_squared_error: 0.492063}
[2022-11-11T05:43:26] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:43:28] [info] | predict | epoch 0 | updates 64 | {categorical_accuracy: 0.8873} | batches 40 | time 1286ms
[2022-11-11T05:43:29] [info] | train | epoch 0 | updates 96 | {mean_squared_error: 0.430096}
[2022-11-11T05:43:29] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:43:30] [info] | predict | epoch 0 | updates 96 | {categorical_accuracy: 0.9057} | batches 40 | time 1378ms
[2022-11-11T05:48:54] [info] | thirdai 0.5.2+d0bc1275
[2022-11-11T05:48:54] [info] | args | Namespace(hidden_dim=10000, hidden_sparsity=0.05, learning_rate=0.0001, log_file='workspace/mnist/mnist.log', log_level='info', log_loss_frequency=32, log_to_stderr=True, num_epochs=10, num_hidden=1, rebuild_hash_tables=100000, reconstruct_hash_functions=10000, resume=False, save_best_per='', save_frequency=32, save_prefix='workspace/mnist/', test_metrics=['categorical_accuracy'], train_metrics=['mean_squared_error'], validate_frequency=32, workspace='workspace/mnist')
[2022-11-11T05:48:54] [info] | env  | {'load_before_experiment': 1.12, 'platform': 'Linux-5.4.0-126-generic-x86_64-with-glibc2.29', 'platform_version': '#142-Ubuntu SMP Fri Aug 26 12:12:57 UTC 2022', 'platform_release': '5.4.0-126-generic', 'architecture': 'x86_64', 'processor': 'x86_64', 'hostname': 'ubuntu9', 'ram_gb': 252, 'num_cores': 48, 'thirdai.version': '0.5.2+d0bc1275'}
[2022-11-11T05:48:54] [info] | Loaded 60000 vectors from 'workspace/mnist/mnist' in 0 seconds.
[2022-11-11T05:48:54] [info] | Loaded 10000 vectors from 'workspace/mnist/mnist.t' in 0 seconds.
[2022-11-11T05:48:54] [info] | 
======================= Bolt Model =======================
input_1 (Input): dim=784
input_1 -> fc_1 (FullyConnected): dim=10000, sparsity=0.05, act_func=ReLU
fc_1 -> fc_2 (FullyConnected): dim=10, sparsity=1, act_func=Softmax
============================================================

[2022-11-11T05:48:55] [info] | train | epoch 0 | updates 32 | {mean_squared_error: 0.577786}
[2022-11-11T05:48:55] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:48:56] [info] | predict | epoch 0 | updates 32 | {categorical_accuracy: 0.8016} | batches 40 | time 947ms
[2022-11-11T05:48:57] [info] | train | epoch 0 | updates 64 | {mean_squared_error: 0.497923}
[2022-11-11T05:48:57] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:48:57] [info] | predict | epoch 0 | updates 64 | {categorical_accuracy: 0.8903} | batches 40 | time 830ms
[2022-11-11T05:48:58] [info] | train | epoch 0 | updates 96 | {mean_squared_error: 0.438934}
[2022-11-11T05:48:58] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:48:59] [info] | predict | epoch 0 | updates 96 | {categorical_accuracy: 0.9144} | batches 40 | time 961ms
[2022-11-11T05:48:59] [info] | train | epoch 0 | updates 128 | {mean_squared_error: 0.397304}
[2022-11-11T05:48:59] [info] | Saving most recent model to workspace/mnist/.last.bolt
[2022-11-11T05:49:00] [info] | predict | epoch 0 | updates 128 | {categorical_accuracy: 0.9231} | batches 40 | time 843ms
```
</details>