### PR TITLE
Added decorater to training and data loading functions

### DIFF
--- a/thirdai_python_package/_distributed_bolt/backend/worker.py
+++ b/thirdai_python_package/_distributed_bolt/backend/worker.py
@@ -136,6 +136,7 @@ class Worker:
         """
         return self.comm.receive_array_partitions(update_id)
 
+    @timed
     def compute_and_store_next_batch_gradients(self) -> bool:
         """
         Computes and stores the gradients on all nodes. After this returns,
@@ -162,6 +163,7 @@ class Worker:
         else:
             return True
 
+    @timed
     def move_to_next_epoch(self):
         self.train_source.restart()
         self._try_load_new_datasets_into_model()


### PR DESCRIPTION
In the last refactoring, we removed timed decorator from calculate_and_store_batch_gradients. It is useful for tracking how much time a single worker on a machine is taking for training which could be useful in debugging some decreasing speedup related issues.