### PR TITLE
Reduce noise in public docs

### DIFF
--- a/docs/public_docs/conf.py
+++ b/docs/public_docs/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import inspect
 
 # -- Project information -----------------------------------------------------
 
@@ -38,7 +39,7 @@ autodoc_default_options = {
     "imported-members": True,
     "undoc-members": True,
     "show-inheritance": True,
-    "special-members": True,
+    "special-members": False,
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -58,3 +59,58 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "sphinx_rtd_theme"
 html_logo = "images/thirdai_logo.png"
 html_static_path = []
+
+
+# Options are `fully-qualified` (thirdai.submodule.) and `short` (submodule.).
+autodoc_typehints_format = "short"
+
+# The type-signature for the class's constructor is not attached with the title.
+autodoc_class_signature = "separated"
+
+
+def fix_pybind11_signatures(
+    app, what, name, obj, options, signature, return_annotation
+):
+    def _remove_self(signature):
+        arguments = signature[1:-1].split(", ")
+        if arguments and arguments[0].startswith("self:"):
+            arguments.pop(0)
+        return "(%s)" % ", ".join(arguments)
+
+    def _reformat_typehints(content):
+        return content.replace(
+            "thirdai._thirdai.",
+            "thirdai." if autodoc_typehints_format == "fully-qualified" else "",
+        )
+
+    if signature is not None:
+        signature = _remove_self(signature)
+        signature = _reformat_typehints(signature)
+
+    if return_annotation is not None:
+        return_annotation = _reformat_typehints(return_annotation)
+
+    return (signature, return_annotation)
+
+
+def skip_pybind11_builtin_members(app, what, name, obj, skip, options):
+    skipped_entries = {
+        "__init__": ["self", "args", "kwargs"],
+        "__new__": ["args", "kwargs"],
+    }
+
+    ref_arguments = skipped_entries.get(name)
+    if ref_arguments is not None:
+        try:
+            arguments = list(inspect.signature(obj).parameters.keys())
+            if arguments == ref_arguments:
+                return True
+        except ValueError:
+            pass
+
+    return None
+
+
+def setup(app):
+    app.connect("autodoc-skip-member", skip_pybind11_builtin_members)
+    app.connect("autodoc-process-signature", fix_pybind11_signatures)


### PR DESCRIPTION
This is same as #927, except applied to external docs. But after #952, the `conf.py` is duplicated in `internal_docs` and `external_docs`. Internal docs [have reduced noise now](http://ec2-3-14-67-7.us-east-2.compute.amazonaws.com/), but the same has not been applied to [external docs](https://thirdailabs.github.io/) - this PR makes the necessary changes to apply it to external docs.

While these are same (internal conf.py, external conf.py) as of now, I'm making the conscious choice to not creating symlinks or anything just to keep the separation, assuming duplication is cheap here than DRY, going ahead.

