### PR TITLE
Delete mac-action (maction)

### DIFF
--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -63,18 +63,3 @@ jobs:
         run: |
           bin/build.py -t all -f THIRDAI_BUILD_LICENSE -m Debug
           bin/cpp-test.sh -V
-
-  cpp-release-tests-mac:
-    runs-on: macos-latest
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, which is the CWD for
-      # the rest of the steps
-      - uses: actions/checkout@v2
-        with:           
-          submodules: 'recursive'
-          token: ${{ secrets.CICD_REPO_ACCESS_TOKEN }}
-          
-      - name: Run all c++ tests
-        run: |
-          bin/build.py -t all -f THIRDAI_BUILD_LICENSE
-          bin/cpp-test.sh --output-on-failure


### PR DESCRIPTION
The Mac runner is much more expensive on gh actions so removing this to cut costs. Running tests on linux should catch almost any error that occurs on Mac, and we still build and test the Mac wheels on push which should be sufficient to catch any errors. 