### PR TITLE
[Distributed] num_omp_threads is always equal to requested number of CPUs

### DIFF
--- a/thirdai_python_package/_distributed_bolt/distributed.py
+++ b/thirdai_python_package/_distributed_bolt/distributed.py
@@ -79,7 +79,7 @@ class RayTrainingClusterConfig:
         # So, we need to change the OMP_NUM_THREADS to support parallization
         num_omp_threads = str(get_num_cpus())
         if requested_cpus_per_node != -1:
-            num_omp_threads = requested_cpus_per_node
+            num_omp_threads = str(requested_cpus_per_node)
         self.logging.info("Setting OMP_NUM_THREADS to " + num_omp_threads)
 
         # We do a deepcopy here so we do not unexpectedly modify the input.


### PR DESCRIPTION
This PR makes sure that the num_omp_threads for any worker is always equal to number of CPUs they run on.