### PR TITLE
Pin numpy to 1.23.5

### DIFF
--- a/thirdai_python_package_tests/bolt_datastructures/test_mlflow_callback.py
+++ b/thirdai_python_package_tests/bolt_datastructures/test_mlflow_callback.py
@@ -1,19 +1,18 @@
+import mlflow
 import pytest
+from test_callbacks import train_model_with_callback
+
+MOCK_TRACKING_URI = "dummy link"
+MOCK_EXPERIMENT_NAME = "dummy experiment"
+MOCK_RUN_NAME = "dummy run"
+MOCK_DATASET_NAME = "dummy dataset"
+MOCK_EXPERIMENT_ARGS_KEY = "dummy key"
+MOCK_EXPERIMENT_ARGS_VALUE = "dummy value"
 
 
-@pytest.mark.xfail
 @pytest.mark.unit
 def test_mlflow_callback(mocker):
     # Import here to avoid collection error since experimental is not defined in release mode.
-    import mlflow
-    from test_callbacks import train_model_with_callback
-
-    MOCK_TRACKING_URI = "dummy link"
-    MOCK_EXPERIMENT_NAME = "dummy experiment"
-    MOCK_RUN_NAME = "dummy run"
-    MOCK_DATASET_NAME = "dummy dataset"
-    MOCK_EXPERIMENT_ARGS_KEY = "dummy key"
-    MOCK_EXPERIMENT_ARGS_VALUE = "dummy value"
     from thirdai.experimental import MlflowCallback
 
     set_tracking_uri_mock = mocker.patch("mlflow.set_tracking_uri")


### PR DESCRIPTION
This pins numpy version to 1.23.5 (the last known working version). 1.24.0 breaks a lot of our tests and also mlflow (which we will have to wait for a fix). 
