### PR TITLE
Moving keygen demo test to use small census dataset

### DIFF
--- a/licensing/python_tests/test_demo_licensing.py
+++ b/licensing/python_tests/test_demo_licensing.py
@@ -28,7 +28,7 @@ def test_census_key_works_on_small_census():
                 output.write(f"{line}")
     model = get_udt_census_income_model()
     model.train(small_census_filename, epochs=1, learning_rate=0.01)
-    # os.remove(small_census_filename)
+    os.remove(small_census_filename)
 
 
 def test_census_key_fails_on_others():


### PR DESCRIPTION
This cleans up our license counting so that the census count isn't skewed