### PR TITLE
Use set(..) instead of option(...) to disable prometheus testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,8 @@ add_subdirectory(deps/googletest EXCLUDE_FROM_ALL)
 add_subdirectory(deps/spdlog EXCLUDE_FROM_ALL)
 # Turn off prometheus-cpp's testing build so that we don't try to build two
 # copies of gmock
-option(ENABLE_TESTING "" OFF)
-option(ENABLE_PUSH "" OFF)
+set(ENABLE_TESTING OFF)
+set(ENABLE_PUSH OFF)
 add_subdirectory(deps/prometheus-cpp EXCLUDE_FROM_ALL)
 
 # PERFORMANCE_COMPARISON is always enabled by default in cereal CMakeLists which


### PR DESCRIPTION
We want testing disabled for prometheus - possibly to avoid google-test conflicts. This is currently attempted to be done using `option(....)` instead of `set(...)`. This leads to the following error log in a build I'm attempting:


<details> 
<summary> Before (failure at configure prometheus) e51d2c0d </summary>

```
-- Project name: ThirdAI
-- Project version: 0.5.10+e51d2c0d
====================================
	BUILD MODE: Release
====================================
	Building with feature flags: THIRDAI_EXPOSE_ALL
	Feature flags seperated into CMake List: THIRDAI_EXPOSE_ALL
	C++ compiler: /usr/bin/c++
	C compiler: /usr/bin/cc
====================================
-- pybind11 v2.10.0 dev1
-- Build spdlog: 1.10.0
-- Build type: Release
CMake Error at deps/prometheus-cpp/cmake/googlemock-3rdparty-config.cmake:5 (add_library):
  add_library cannot create target "gmock_main" because another target with
  the same name already exists.  The existing target is a static library
  created in source directory
  "/home/minion/buildbot/worker/Universe/build/deps/googletest/googlemock".
  See documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  deps/prometheus-cpp/CMakeLists.txt:86 (find_package)
```
</details>

<details>
<summary> After (no failure, successfull configure) c28bbed8 </summary>

```
-- Project name: ThirdAI
-- Project version: 0.5.10+c28bbed8
====================================
	BUILD MODE: Release
====================================
	Building with feature flags: THIRDAI_EXPOSE_ALL
	Feature flags seperated into CMake List: THIRDAI_EXPOSE_ALL
	C++ compiler: /usr/bin/c++
	C compiler: /usr/bin/cc
====================================
-- pybind11 v2.10.0 dev1
-- Build spdlog: 1.10.0
-- Build type: Release
-- The following features have been enabled:
 * Pull, support for pulling metrics
 * Compression, support for zlib compression of metrics
 * pkg-config, generate pkg-config files
-- The following OPTIONAL packages have been found:
 * OpenMP
 * Python
-- The following REQUIRED packages have been found:
 * Git
 * PythonInterp (required version >= 3.6)
 * PythonLibsNew
 * Threads
 * civetweb-3rdparty
 * ZLIB
-- The following features have been disabled:
 * Push, support for pushing metrics to a push-gateway
 * IYWU, include-what-you-use
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/minion/buildbot/worker/Universe/build/build
Scanning dependencies of target core
Scanning dependencies of target civetweb
```
</summary>