### PR TITLE
[Distributed] DatasetLoader outside THIRDAI_EXPOSE_ALL

### DIFF
--- a/dataset/python_bindings/DatasetPython.cc
+++ b/dataset/python_bindings/DatasetPython.cc
@@ -249,10 +249,6 @@ void createDatasetSubmodule(py::module_& module) {
            "Returns false since text blocks always produce sparse "
            "features.");
 
-  py::class_<DatasetShuffleConfig>(dataset_submodule, "ShuffleConfig")
-      .def(py::init<size_t, uint32_t>(), py::arg("min_vecs_in_buffer") = 64000,
-           py::arg("seed") = time(NULL));
-
   py::class_<Featurizer, FeaturizerPtr>(dataset_submodule,  // NOLINT
                                         "Featurizer");
 
@@ -274,6 +270,10 @@ void createDatasetSubmodule(py::module_& module) {
            py::arg("masked_tokens_percentage"));
 
 #endif
+
+  py::class_<DatasetShuffleConfig>(dataset_submodule, "ShuffleConfig")
+      .def(py::init<size_t, uint32_t>(), py::arg("min_vecs_in_buffer") = 64000,
+           py::arg("seed") = time(NULL));
 
   py::class_<DatasetLoader, DatasetLoaderPtr>(dataset_submodule,
                                               "DatasetLoader")


### PR DESCRIPTION
Distributed uses `getLabeledDatasetLoader`https://github.com/ThirdAILabs/Universe/blob/888abc09b1d64bc6c6c9a7ff470ad6aefe32a9ef/auto_ml/python_bindings/AutomlPython.cc#L111 which returns DatasetLoaderPtr; hence it needs DatasetLoader to be outside THIRDAI_EXPOSE_ALL to work. 