### PR TITLE
Consistent config cipher

### DIFF
--- a/auto_ml/src/config/ModelConfig.cc
+++ b/auto_ml/src/config/ModelConfig.cc
@@ -10,8 +10,6 @@
 #include <auto_ml/src/config/ArgumentMap.h>
 #include <dataset/src/utils/SafeFileIO.h>
 #include <fstream>
-#include <iostream>
-#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Apparently 

```c++
std::mt19937 rand(8256387);
std::uniform_int_distribution<uint8_t> dist;

for (int i = 0; i < 10; i++) {
  ... = dist(rand);
}
```
is not consistent across different machines :(