### PR TITLE
Fix windows-builds on CI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,7 @@ concurrency:
 on: 
   push: 
     branches: [main]
+
   release:
     types:
       - published
@@ -26,8 +27,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO(Josh): Decide if we want to add windows back at all
-        # os: [windows-2019, ubuntu-20.04]
         os: [ubuntu-20.04]
         include:
           - name: macos-x86_64
@@ -41,7 +40,6 @@ jobs:
             deployment_target: "11.0"
             cmake_additional_args: "-DTHIRDAI_BUILD_OPENSSL_FROM_SOURCE=ON -DOPENSSL_CROSS_COMPILE_MACOSX_ARM=ON"
 
-
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
@@ -50,6 +48,22 @@ jobs:
         with:           
           submodules: 'recursive'
           token: ${{ secrets.CICD_REPO_ACCESS_TOKEN }}
+
+      - name: Inject local version identifier for non tag builds
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        shell: bash
+        run: |-
+          echo "THIRDAI_BUILD_IDENTIFIER=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+
+      - name: Install dependencies with vcpkg
+        working-directory: C:\vcpkg
+        run: |
+          $Env:VCPKG_BUILD_TYPE = 'release'
+          $Env:VCPKG_DEFAULT_TRIPLET = 'x64-windows-static' 
+          .\vcpkg install zlib:x64-windows-static openssl:x64-windows-static
+          .\vcpkg upgrade --no-dry-run # In case there are new builds available after cache restoration
+        shell: powershell
 
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.9.0
@@ -60,6 +74,8 @@ jobs:
           # https://github.com/facebook/folly/issues/1762
           CIBW_ENVIRONMENT_LINUX: >
             CMAKE_ARGS="-DOPENSSL_ROOT_DIR:PATH=/usr/lib64/openssl11;/usr/include/openssl11"
+            THIRDAI_BUILD_IDENTIFIER=${{ env.THIRDAI_BUILD_IDENTIFIER }}
+
 
           # The following is to relax the discovery timeout (from a default 5) so that
           # cibuildwheel GitHub workflow does not timeout on test-discovery.
@@ -70,14 +86,17 @@ jobs:
           #
           # TODO(GH-779): Fix the multiple libraries existing.
           CIBW_ENVIRONMENT_WINDOWS: >
-              CMAKE_ARGS="-DTHIRDAI_GTEST_DISCOVERY_TIMEOUT=30"
+              CMAKE_ARGS='-DTHIRDAI_GTEST_DISCOVERY_TIMEOUT=30 -DVCPKG_TARGET_TRIPLET=x64-windows-static -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake'
               KMP_DUPLICATE_LIB_OK=TRUE
+              THIRDAI_BUILD_IDENTIFIER=${{ env.THIRDAI_BUILD_IDENTIFIER }}
 
           CIBW_ENVIRONMENT_MACOS:
             CMAKE_ARGS='${{ matrix.cmake_additional_args }}'
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}
             OPENSSL_ROOT_DIR=/usr/local/opt/openssl 
             OPENSSL_LIBRARIES=/usr/local/opt/openssl/lib
+            THIRDAI_BUILD_IDENTIFIER=${{ env.THIRDAI_BUILD_IDENTIFIER }}
+
 
           # Mac and windows will use this path, since they do not run in docker
           THIRDAI_LICENSE_PATH: ${{ github.workspace }}/docker/product/slim/license.serialized 
@@ -101,6 +120,7 @@ jobs:
             yum install golang -y
           CIBW_TEST_EXTRAS: "test"
           CIBW_TEST_COMMAND: pytest {package} --ignore-glob={package}/deps -m release
+          CIBW_TEST_COMMAND_WINDOWS: rem
 
           # Build both x86_64 and arm64 (apple silicon)
           CIBW_ARCHS_MACOS: ${{ matrix.archs }}


### PR DESCRIPTION
Uses `vcpkg` to obtain OpenSSL and ZLIB required for compiling.

Note that this does not re-enable windows workflow to run regularly, it just adds the working state CI code into main for future developer's reference.

We're likely to keep a built wheel directory outside PyPI for distributing windows wheels, albeit unsupported on CI (to remove any trouble while developing). This also adds a build identifier (commit) to keep track of any additional patches on top and to avoid conflict with the actual tagged version.