### PR TITLE
Guard vcpkg installation with windows runner check

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -57,6 +57,7 @@ jobs:
 
 
       - name: Install dependencies with vcpkg
+        if: ${{ startsWith(runner.os, 'windows') }}
         working-directory: C:\vcpkg
         run: |
           $Env:VCPKG_BUILD_TYPE = 'release'


### PR DESCRIPTION
Oops, missed that while testing isolated to windows. 😓 