### PR TITLE
Closing potential demo licensing loophole of a data source with a misleading resource name

### DIFF
--- a/auto_ml/src/models/Generator.h
+++ b/auto_ml/src/models/Generator.h
@@ -259,7 +259,9 @@ class QueryCandidateGenerator {
    * and there is a source column in the passed in filename.
    */
   void train(const std::string& filename, bool use_supervised = true) {
-    licensing::TrainPermissionsToken token(filename);
+    // TODO(Nick): Pass in data source directly when this is moved to UDT V2
+    auto source = std::make_shared<dataset::FileDataSource>(filename);
+    licensing::TrainPermissionsToken token(source);
 
     auto [source_column_index, target_column_index] = mapColumnNamesToIndices(
         /* file_name = */ filename);

--- a/auto_ml/src/udt/backends/UDTClassifier.cc
+++ b/auto_ml/src/udt/backends/UDTClassifier.cc
@@ -74,7 +74,7 @@ void UDTClassifier::train(
   utils::train(_model, train_dataset, train_config, batch_size,
                max_in_memory_batches,
                /* freeze_hash_tables= */ _freeze_hash_tables,
-               licensing::TrainPermissionsToken(data->resourceName()));
+               licensing::TrainPermissionsToken(data));
 
   /**
    * For binary classification we tune the prediction threshold to optimize some

--- a/auto_ml/src/udt/backends/UDTSVMClassifier.cc
+++ b/auto_ml/src/udt/backends/UDTSVMClassifier.cc
@@ -55,7 +55,7 @@ void UDTSVMClassifier::train(
 
   utils::trainInMemory(_model, {{train_dataset}, labels}, train_config,
                        _freeze_hash_tables,
-                       licensing::TrainPermissionsToken(data->resourceName()));
+                       licensing::TrainPermissionsToken(data));
 }
 
 py::object UDTSVMClassifier::evaluate(const dataset::DataSourcePtr& data,

--- a/dataset/src/DataSource.h
+++ b/dataset/src/DataSource.h
@@ -25,6 +25,10 @@ class DataSource {
 
 using DataSourcePtr = std::shared_ptr<DataSource>;
 
+// This class should remain final because we require for demo licensing that the
+// passed in source is a FileDataSource so the user can't trickily add extra
+// functionality (and making it not final would allow it to be extended and
+// its methods overwritten with tricky behavior).
 class FileDataSource final : public DataSource {
  public:
   explicit FileDataSource(const std::string& filename)
@@ -71,6 +75,9 @@ class FileDataSource final : public DataSource {
   std::string resourceName() const final { return _filename; }
 
  private:
+  // In the same vein as the above comment about demo licensing, these fields
+  // should not be settable after the constructor, since we want _filename to
+  // always refer to _file.
   std::ifstream _file;
   std::string _filename;
 };

--- a/licensing/src/CheckLicense.h
+++ b/licensing/src/CheckLicense.h
@@ -25,13 +25,13 @@ class TrainPermissionsToken {
 
   /**
    * Creates a TrainPermissionsToken corresponding to a passed in training
-   * file path. If the user does not have an entitlement allowing them to
-   * train on the file, this will throw an error. If licensing is
+   * data source. If the user does not have an entitlement allowing them to
+   * train on the data source, this will throw an error. If licensing is
    * disabled, this will always succeed. To prevent unauthorized API use, you
    * should only use this access token to train models with the passed in
    * training file.
    */
-  explicit TrainPermissionsToken(const std::string& train_file_path);
+  explicit TrainPermissionsToken(const dataset::DataSourcePtr& source);
 };
 
 // If license checking is enabled, verifies the license is valid and throws an

--- a/licensing/src/CheckLicenseDisabled.cc
+++ b/licensing/src/CheckLicenseDisabled.cc
@@ -9,8 +9,8 @@
 namespace thirdai::licensing {
 
 TrainPermissionsToken::TrainPermissionsToken(
-    const std::string& train_file_path) {
-  (void)train_file_path;
+    const dataset::DataSourcePtr& training_source) {
+  (void)training_source;
 }
 
 TrainPermissionsToken::TrainPermissionsToken() {}


### PR DESCRIPTION
Luckily not possible to replicate because we don't allow passing a raw data source to UDT