### PR TITLE
fix slack release failure notifications

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -180,22 +180,24 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
 
-    - name: Notify slack success  # Ref: https://github.com/marketplace/actions/slack-notify-build
-      if: success()
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      uses: voxmedia/github-action-slack-notify-build@v1
-      with:
-        channel_id: pypi_package_releases
-        status: SUCCESS
-        color: good
+  notify_slack_success:
+    name: Notify slack success  # Ref: https://github.com/marketplace/actions/slack-notify-build
+    if: success()
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: voxmedia/github-action-slack-notify-build@v1
+    with:
+      channel_id: pypi_package_releases
+      status: SUCCESS
+      color: good
 
-    - name: Notify slack fail
-      if: failure()
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      uses: voxmedia/github-action-slack-notify-build@v1
-      with:
-        channel_id: pypi_package_releases
-        status: FAILED
-        color: danger
+  notify_slack_failure:
+    name: Notify slack fail
+    if: failure()
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: voxmedia/github-action-slack-notify-build@v1
+    with:
+      channel_id: pypi_package_releases
+      status: FAILED
+      color: danger


### PR DESCRIPTION
the two steps for slack notifications were tabbed only under the section where we upload to real pypi, not the whole action. This PR makes that change so if at any point in the action we fail, we'll notify on slack, not just on a failed upload to real pypi.