### PR TITLE
Add tolerance and increase model size for Dragon Tests

### DIFF
--- a/compression/python_tests/test_dragon.py
+++ b/compression/python_tests/test_dragon.py
@@ -50,7 +50,11 @@ def test_get_set_values_dragon_vector():
     new_first_layer_weights = first_layer.weights.copy().flatten()
 
     # checking whether the gradients are correct
-    # set is parallel in dragon and is not thread safe and there might be a race condition when two indices go the sum bucket in the dragon vector and are picked up by two threads at the same time. that is indices[i], values[j] is possible if hash(i) == hash(j) and are in a race condition.
+    # set is parallel in dragon and is not thread safe and there
+    # might be a race condition when two indices go the sum bucket
+    # in the dragon vector and are picked up by two threads at the same time.
+    # that is indices[i], values[j] is possible if hash(i) == hash(j) and are
+    # in a race condition.
 
     number_weights_mismatch = 0
     for i, values in enumerate(new_first_layer_weights):


### PR DESCRIPTION
Note : Dragon Compression is non-deterministic as two elements if mapped to the same bucket and picked up by two different threads at the same time will result in non-determinism.
The size of the weight matrix we compress is 10000. Added tolerance of 6 that is the number of weights that can be incorrect. With this modification, both get_set and concat tests for Dragon fail 0 times out of a 1000 runs.