### PR TITLE
Enable `delvewheel` to repair windows-wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,7 +14,7 @@ concurrency:
 # for more details.
 on: 
   push: 
-    branches: [main, delvewheel]
+    branches: [main]
 
   release:
     types:


### PR DESCRIPTION
Change introduces `delvewheel`[1]  to add missing OpenMP libs 
to get the windows-distribution better portable.

[1] https://pypi.org/project/delvewheel/

```
[jerin@guines delvewheel-test]$ find thirdai.libs | grep "dll"
thirdai.libs/libomp140.x86_64-1bc3435a2096f922cfee744b10f0b66d.dll
```