### PR TITLE
Better type inference

### DIFF
--- a/thirdai_python_package/data/type_inference.py
+++ b/thirdai_python_package/data/type_inference.py
@@ -36,7 +36,7 @@ def _is_multi_categorical(column: pd.Series) -> Tuple[bool, Optional[str]]:
     most_occurring_delimiter = max(ratios, key=lambda entry: ratios[entry])
     most_occurring_ratio = ratios[most_occurring_delimiter]
 
-    if most_occurring_ratio > _MULTI_CATEGORICAL_DELIMITER_RATIO_THRESHOLD:
+    if most_occurring_ratio >= _MULTI_CATEGORICAL_DELIMITER_RATIO_THRESHOLD:
         return True, most_occurring_delimiter
 
     return False, None


### PR DESCRIPTION
For multi-categorical we have to decrease the delimiter ratio (may be to 1.1), so for the file in #1449 the ratios of all categorical delimiters are ``{';': 1.0, ':': 1.16, '-': 1.0, '\t': 1.0, '|': 1.0}`` , so based on current threshold it would be treated as categorical, but in theory its a multi-categorical. It would be enough if for every 10 rows there is multi-categorical split of one, for us to decide it as multi-categorical.