### PR TITLE
Prevent files from being downloaded to licensing directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ clang_tidy_logs
 licensing/src/methods/server/license-server
 licensing/src/methods/server/license-server-max-*
 
+# Versioning serialized archives
+versioning/python_tests/serialized_classes/
+
 # -- Begin vim .gitignore
 # Swap
 [._]*.s[a-v][a-z]

--- a/licensing/python_tests/test_license_server.py
+++ b/licensing/python_tests/test_license_server.py
@@ -8,10 +8,23 @@ import subprocess
 import pytest
 
 
-@pytest.mark.unit
-def test_go_server():
+@pytest.fixture
+def switch_to_server_dir():
+    original_directory = os.getcwd()
+
     go_src_directory = (
         pathlib.Path(__file__).parent.parent / "src" / "methods" / "server"
     )
+
+    # Change to go package directory
     os.chdir(go_src_directory)
+
+    yield
+
+    # Return to original working directory
+    os.chdir(original_directory)
+
+
+@pytest.mark.unit
+def test_go_server(switch_to_server_dir):
     assert subprocess.run(f"go test", shell=True).returncode == 0


### PR DESCRIPTION
Right now the licensing serve test change the working directory. This causes future tests to be run from that directory, which means that when we download datasets and create files they are located in the licensing server directory instead of our usual build directory. This fixes the issue by restoring the original directory after running the tests