### PR TITLE
Fix flaky `tabular_get_set_parameters` test

### DIFF
--- a/auto_ml/python_tests/test_udt_tabular.py
+++ b/auto_ml/python_tests/test_udt_tabular.py
@@ -1,5 +1,6 @@
 import copy
 
+import numpy as np
 import pytest
 from download_dataset_fixtures import download_census_income
 from model_test_utils import (
@@ -46,12 +47,14 @@ def test_udt_tabular_get_set_parameters(download_census_income):
 
     untrained_model.set_parameters(model.get_parameters())
 
-    old_acc = compute_predict_batch_accuracy(model, test_samples, use_class_name=True)
-    new_acc = compute_predict_batch_accuracy(
-        untrained_model, test_samples, use_class_name=True
-    )
+    batch = [x[0] for x in test_samples]
 
-    assert old_acc == new_acc
+    old_activations = model.predict_batch(batch)
+    new_activations = untrained_model.predict_batch(batch)
+
+    assert (
+        np.argmax(old_activations, axis=1) == np.argmax(new_activations, axis=1)
+    ).all()
 
 
 def test_udt_tabular_save_load(train_udt_tabular, download_census_income):


### PR DESCRIPTION
This test was failing because while the parameters where copied between the models, the new `untrained_model` was created as a copy of the original model before the original model saw any data. This is important because the labels in this dataset are strings, and the mappings of the labels to neurons is determined when data is first processed. This means that randomly the test would fail because the `untrained_model` would see the labels in a different order and so it would map the labels to different neurons, but since the parameters where copied, it would predict the opposite of the intended class. 