### PR TITLE
Clean up neural DB

### DIFF
--- a/thirdai_python_package/neural_db/neural_db.py
+++ b/thirdai_python_package/neural_db/neural_db.py
@@ -144,10 +144,6 @@ class NeuralDB:
             raise ValueError(f"Incompatible UDT model. Cannot find a query column.")
         if id_col is None:
             raise ValueError(f"Incompatible UDT model. Cannot find an id column.")
-        if id_delimiter is None:
-            raise ValueError(
-                f"Incompatible UDT model. Id column must have a delimiter."
-            )
 
         model = Mach(
             id_col=id_col,


### PR DESCRIPTION
These methods are currently not used anywhere so just removing it for now, we can always add them back once we require them. Currently the model checks for delimiter in the target column and made that mandatory which is not required, so just making it None.