### PR TITLE
Fixes-uninitialized-value-error on blade

### DIFF
--- a/data/src/TensorConversion.cc
+++ b/data/src/TensorConversion.cc
@@ -61,8 +61,10 @@ std::vector<bolt::TensorList> toTensorBatches(
           batch_values.insert(batch_values.end(), values_row.begin(),
                               values_row.end());
         } else {
-          float fill_value = (value_fill_type == ValueFillType::SumToOne) ? 1.0 / indices_row.size() : 1.0;
-          
+          float fill_value = (value_fill_type == ValueFillType::SumToOne)
+                                 ? 1.0 / indices_row.size()
+                                 : 1.0;
+
           for (size_t j = 0; j < indices_row.size(); j++) {
             batch_values.push_back(fill_value);
           }


### PR DESCRIPTION
On blade, we were getting the following error on building Universe:
```
   /tmp/pip-req-build-v6rpxwpe/data/src/TensorConversion.cc: In function ‘_ZN7thirdai4data15toTensorBatchesERKNS0_9ColumnMapERKSt6vectorINS0_13OutputColumnsESaIS5_EEm._omp_fn.0’:
    /tmp/pip-req-build-v6rpxwpe/data/src/TensorConversion.cc:64:17: error: ‘fill_value’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       64 |           float fill_value;
          |                 ^~~~~~~~~~
    At global scope:
    cc1plus: error: unrecognized command line option ‘-Wno-ignored-optimization-argument’ [-Werror]
```