### PR TITLE
Fix Wheel GH action

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,9 +16,8 @@ on:
   push: 
     branches: [main]
 
-  release:
-    types:
-      - published
+  push:
+    tags: [ 'v*.*.*' ]
   workflow_dispatch:  
 
 


### PR DESCRIPTION
Attempt to fix issue with releases checking out the commit for the tag instead of the tag itself when running action to build and publish wheels. 

https://github.com/orgs/community/discussions/45144