### PR TITLE
Replace newlines with spaces in introduce with fast approximation

### DIFF
--- a/auto_ml/src/cold_start/ColdStartUtils.cc
+++ b/auto_ml/src/cold_start/ColdStartUtils.cc
@@ -120,6 +120,7 @@ dataset::cold_start::ColdStartDataSourcePtr concatenatedDocumentDataSource(
       output_sample.append(" ");
     }
     text::replacePunctuationWithSpaces(output_sample);
+    text::replaceNewlinesWithSpaces(output_sample);
     samples.push_back(std::move(output_sample));
   }
 

--- a/utils/StringManipulation.cc
+++ b/utils/StringManipulation.cc
@@ -363,4 +363,10 @@ void replacePunctuationWithSpaces(std::string& string) {
       [](const char c) -> bool { return std::ispunct(c); }, ' ');
 }
 
+void replaceNewlinesWithSpaces(std::string& string) {
+  std::replace_if(
+      string.begin(), string.end(),
+      [](const char c) -> bool { return c == '\n' || c == '\r'; }, ' ');
+}
+
 }  // namespace thirdai::text

--- a/utils/StringManipulation.h
+++ b/utils/StringManipulation.h
@@ -98,4 +98,9 @@ std::vector<std::wstring> splitOnWhitespace(const std::wstring& text);
  */
 void replacePunctuationWithSpaces(std::string& string);
 
+/**
+ * Replaces \n and \r characters in string with whitespace.
+ */
+void replaceNewlinesWithSpaces(std::string& string);
+
 }  // namespace thirdai::text


### PR DESCRIPTION
Got issues where there are unquoted newlines in a column after going through the fast approximation column concatenation process. This should fix it.