### PR TITLE
Embedding Function

### DIFF
--- a/thirdai_python_package/neural_db/neural_db.py
+++ b/thirdai_python_package/neural_db/neural_db.py
@@ -344,11 +344,13 @@ class NeuralDB:
 
         ray_version = ray.__version__
         if LooseVersion(ray_version) >= LooseVersion("2.7"):
-            warnings.warn("""
+            warnings.warn(
+                """
                 Using ray version 2.7 or higher requires specifying a remote or NFS storage path. 
                 Support for local checkpoints has been discontinued in these versions. 
                 Refer to https://github.com/ray-project/ray/issues/37177 for details.
-                """.strip())
+                """.strip()
+            )
 
         if not isinstance(documents, list) or not all(
             isinstance(doc, CSV) for doc in documents


### PR DESCRIPTION
Get embeddings from neural db. Right now, getting embeddings from neuraldb for a query includes making a call to the underlying mach model. 
Ex : `db._savable_state.model.model.embedding_representation([{"query":query} for query in queries])`

With this PR, it would be something like `db.embedding_representation(queries)`