### PR TITLE
Reducing flakiness from document connector tests

### DIFF
--- a/thirdai_python_package_tests/neural_db/ndb_utils.py
+++ b/thirdai_python_package_tests/neural_db/ndb_utils.py
@@ -76,8 +76,6 @@ URL_NO_RESPONSE_META = "url-no-response"
 PPTX_META = "pptx"
 TXT_META = "txt"
 EML_META = "eml"
-SQL_META = "sql"
-SHAREPOINT_META = "sharepoint"
 SENTENCE_PDF_META = "sentence-pdf"
 SENTENCE_DOCX_META = "sentence-docx"
 
@@ -236,21 +234,6 @@ def docs_with_meta():
         ndb.Unstructured(PPTX_FILE, metadata=meta(PPTX_META)),
         ndb.Unstructured(TXT_FILE, metadata=meta(TXT_META)),
         ndb.Unstructured(EML_FILE, metadata=meta(EML_META)),
-        ndb.SQLDatabase(
-            engine=ENGINE,
-            table_name=TABLE_NAME,
-            id_col="id",
-            strong_columns=["content"],
-            weak_columns=["content"],
-            reference_columns=["content"],
-            chunk_size=3,
-            metadata=meta(SQL_META),
-        ),
-        ndb.SharePoint(
-            ctx=CLIENT_CONTEXT,
-            library_path=LIBRARY_PATH,
-            metadata=meta(SHAREPOINT_META),
-        ),
         ndb.SentenceLevelPDF(PDF_FILE, metadata=meta(SENTENCE_PDF_META)),
         ndb.SentenceLevelDOCX(DOCX_FILE, metadata=meta(SENTENCE_DOCX_META)),
     ]
@@ -264,8 +247,6 @@ metadata_constraints = [
     PPTX_META,
     TXT_META,
     EML_META,
-    SQL_META,
-    SHAREPOINT_META,
     SENTENCE_PDF_META,
     SENTENCE_DOCX_META,
 ]

--- a/thirdai_python_package_tests/neural_db/test_neural_db.py
+++ b/thirdai_python_package_tests/neural_db/test_neural_db.py
@@ -6,7 +6,7 @@ from typing import List
 import pytest
 from ndb_utils import (
     PDF_FILE,
-    all_doc_getters,
+    all_local_doc_getters,
     create_simple_dataset,
     docs_with_meta,
     metadata_constraints,
@@ -53,12 +53,12 @@ ARBITRARY_QUERY = "This is an arbitrary search query"
 
 def insert_works(db: ndb.NeuralDB, docs: List[ndb.Document]):
     db.insert(docs, train=False)
-    assert len(db.sources()) == 11
+    assert len(db.sources()) == 9
 
     initial_scores = [r.score for r in db.search(ARBITRARY_QUERY, top_k=5)]
 
     db.insert(docs, train=True)
-    assert len(db.sources()) == 11
+    assert len(db.sources()) == 9
 
     assert [r.score for r in db.search(ARBITRARY_QUERY, top_k=5)] != initial_scores
 
@@ -166,13 +166,13 @@ def test_neural_db_loads_from_model_bazaar():
 
 def test_neural_db_all_methods_work_on_new_model():
     db = ndb.NeuralDB("user")
-    all_docs = [get_doc() for get_doc in all_doc_getters]
+    all_docs = [get_doc() for get_doc in all_local_doc_getters]
     all_methods_work(db, all_docs, assert_acc=False)
 
 
 def test_neural_db_all_methods_work_on_loaded_bazaar_model():
     db = db_from_bazaar()
-    all_docs = [get_doc() for get_doc in all_doc_getters]
+    all_docs = [get_doc() for get_doc in all_local_doc_getters]
     all_methods_work(db, all_docs, assert_acc=True)
 
 


### PR DESCRIPTION
Removes DocumentConector from the neural_db methods test to reduce the flakiness