### PR TITLE
Make type annotations compatible with python3.8

### DIFF
--- a/thirdai_python_package/neural_db/documents.py
+++ b/thirdai_python_package/neural_db/documents.py
@@ -461,7 +461,7 @@ class CSV(Document):
             df = filterer.filter_df_column(df, column_name)
         return df[self.id_column].to_list()
 
-    def id_map(self) -> Dict[str, int] | None:
+    def id_map(self) -> Optional[Dict[str, int]]:
         return self.orig_to_assigned_id
 
     def strong_text(self, element_id: int) -> str:


### PR DESCRIPTION
Type annotations like `int | None` was added in python 3.10, so using this as a type declaration breaks earlier python wheels (ex: https://github.com/ThirdAILabs/Universe/actions/runs/6815117246/job/18533534375)