### PR TITLE
'mock_s3' changed to 'mock_aws'

### DIFF
--- a/auto_ml/python_tests/test_udt_s3.py
+++ b/auto_ml/python_tests/test_udt_s3.py
@@ -4,7 +4,7 @@ import boto3
 import pytest
 from download_dataset_fixtures import download_census_income
 from model_test_utils import compute_evaluate_accuracy, get_udt_census_income_model
-from moto import mock_s3
+from moto import mock_aws
 from thirdai import bolt
 
 pytestmark = [pytest.mark.unit, pytest.mark.release]
@@ -26,7 +26,7 @@ def aws_credentials():
 
 @pytest.fixture(scope="function")
 def s3(aws_credentials):
-    with mock_s3():
+    with mock_aws():
         yield boto3.client("s3", region_name="us-east-1")
 
 
@@ -53,7 +53,7 @@ def train_and_evaluate(model_to_test, train_path, test_path, inference_samples):
     assert acc >= ACCURACY_THRESHOLD
 
 
-@mock_s3
+@mock_aws
 def test_udt_census_income_s3(download_census_income, s3):
     local_train_file, local_test_file, inference_samples = download_census_income
     s3_train_path, s3_test_path = setup_census_on_s3(

--- a/telemetry/python_tests/test_telemetry_s3.py
+++ b/telemetry/python_tests/test_telemetry_s3.py
@@ -1,7 +1,7 @@
 import boto3
 import botocore
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 from moto.server import ThreadedMotoServer
 from telemetry_testing_utils import THIRDAI_TEST_TELEMETRY_PORT, run_udt_telemetry_test
 from thirdai import telemetry
@@ -22,7 +22,7 @@ def moto_server_fixture():
     return server
 
 
-@mock_s3
+@mock_aws
 def test_udt_telemetry_s3():
     s3 = boto3.client("s3")
     s3.create_bucket(Bucket=THIRDAI_TEST_TELEMETRY_BUCKET)
@@ -34,7 +34,7 @@ def test_udt_telemetry_s3():
     run_udt_telemetry_test(telemetry_start_method=("s3", s3_path))
 
 
-@mock_s3
+@mock_aws
 def test_telemetry_bad_s3_file():
     with pytest.raises(
         botocore.exceptions.ClientError, match="The specified bucket does not exist"

--- a/thirdai_python_package_tests/dataset/test_s3_csv_datasource.py
+++ b/thirdai_python_package_tests/dataset/test_s3_csv_datasource.py
@@ -3,7 +3,7 @@ import os
 
 import boto3
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 
 pytestmark = [pytest.mark.unit, pytest.mark.release]
 
@@ -28,11 +28,11 @@ def aws_credentials():
 
 @pytest.fixture(scope="function")
 def s3(aws_credentials):
-    with mock_s3():
+    with mock_aws():
         yield boto3.client("s3", region_name="us-east-1")
 
 
-def setup_mock_s3(s3):
+def setup_mock_aws(s3):
     s3.create_bucket(Bucket="test_bucket")
     s3.put_object(
         Bucket=bucket_name,
@@ -67,9 +67,9 @@ def load_all_lines(storage_path, batch_size):
     return lines
 
 
-@mock_s3
+@mock_aws
 def test_s3_data_source_by_batch(s3):
-    setup_mock_s3(s3)
+    setup_mock_aws(s3)
 
     batches = load_all_batches(
         storage_path=f"s3://{bucket_name}/find/numbers/ones", batch_size=batch_size
@@ -88,9 +88,9 @@ def test_s3_data_source_by_batch(s3):
 
 # This is similar to test_s3_data_source_by_batch, but additionally ensures
 # that the linewise loading is correct
-@mock_s3
+@mock_aws
 def test_s3_data_source_by_line(s3):
-    setup_mock_s3(s3)
+    setup_mock_aws(s3)
 
     lines = load_all_lines(
         storage_path=f"s3://{bucket_name}/find/numbers/ones", batch_size=batch_size


### PR DESCRIPTION
Latest release of moto has changed to mock_aws

https://pypi.org/project/moto/5.0.0/

```
E   ImportError: cannot import name 'mock_s3' from 'moto' (/home/runner/.local/lib/python3.10/site-packages/moto/__init__.py)
_ ERROR collecting thirdai_python_package_tests/dataset/test_s3_csv_datasource.py _
ImportError while importing test module '/home/runner/work/Universe/Universe/thirdai_python_package_tests/dataset/test_s3_csv_datasource.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
../thirdai_python_package_tests/dataset/test_s3_csv_datasource.py:6: in <module>
    from moto import mock_s3
E   ImportError: cannot import name 'mock_s3' from 'moto' (/home/runner/.local/lib/python3.10/site-packages/moto/__init__.py)
```