### PR TITLE
Fix infrequent infinite loop

### DIFF
--- a/thirdai_python_package_tests/neural_db/ndb_utils.py
+++ b/thirdai_python_package_tests/neural_db/ndb_utils.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from thirdai import neural_db as ndb
 
-#from thirdai_python_package_tests.neural_db.base_connectors import base
+from thirdai_python_package_tests.neural_db.base_connectors import base
 
 
 class Equivalent_doc:

--- a/thirdai_python_package_tests/neural_db/test_neural_db.py
+++ b/thirdai_python_package_tests/neural_db/test_neural_db.py
@@ -63,17 +63,11 @@ def all_methods_work(
     assert_acc: bool,
 ):
     insert_works(db, docs, num_duplicate_docs)
-    print("insert done", flush=True)
     search_works(db, docs, assert_acc)
-    print("search done", flush=True)
     upvote_works(db)
-    print("upvote done", flush=True)
     associate_works(db)
-    print("associate done", flush=True)
     save_load_works(db)
-    print("save load done", flush=True)
     clear_sources_works(db)
-    print("clear done", flush=True)
 
 
 @pytest.mark.parametrize("use_inverted_index", [True, False])
@@ -86,12 +80,6 @@ def test_neural_db_all_methods_work_on_new_model(small_doc_set, use_inverted_ind
         assert_acc=False,
     )
 
-for i in range(100):
-    db = ndb.NeuralDB()
-    all_methods_work(
-        db=db, docs=[ndb.CSV(CSV_FILE), ndb.PDF(PDF_FILE, on_disk=True)], num_duplicate_docs=0, assert_acc=False
-    )
-    print(f"ITERATION {i} COMPLETE")
 
 def test_neuralb_db_all_methods_work_on_new_mach_mixture(small_doc_set):
     number_models = 2


### PR DESCRIPTION
This loop generated random numbers until a set number of them was reached. However there is at least one input to this hash function `h(5397) % 50,000 = 5397` that leads to the hash function going into a cycle and not generating new candidates so that the threshold is never reached to stop. 