### PR TITLE
Fix empty balancing samples edge case

### DIFF
--- a/auto_ml/src/rlhf/BalancingSamples.cc
+++ b/auto_ml/src/rlhf/BalancingSamples.cc
@@ -53,10 +53,6 @@ BalancingSamples::BalancingSamples(std::string indices_col,
 }
 
 data::ColumnMap BalancingSamples::balancingSamples(size_t num_samples) {
-  if (num_samples == 0) {
-    return data::ColumnMap({});
-  }
-
   if (_samples_per_doc.empty()) {
     throw std::runtime_error(
         "Cannot call associate before training, coldstarting, or introducing "


### PR DESCRIPTION
Fix edge case where balancingSamples() returns a column map with no columns when num_balancing_samples = 0