### PR TITLE
default lr 0.001

### DIFF
--- a/thirdai_python_package/neural_db/mach_defaults.py
+++ b/thirdai_python_package/neural_db/mach_defaults.py
@@ -5,10 +5,8 @@ acc_to_stop = 0.95
 
 
 def autotune_from_scratch_min_max_epochs(size):
-    if size < 1000:
-        return 10, 15
     if size < 10000:
-        return 8, 13
+        return 10, 15
     if size < 100000:
         return 5, 10
     if size < 1000000:


### PR DESCRIPTION
0.005 was an artifact of the original pocketllm/playground which was tested with very small docs and never benchmarked

0.001 is what we get all our best numbers with and is what we use for all of our benchmarks



