### PR TITLE
add support for directionless context and char-4 context

### DIFF
--- a/data/python_bindings/DataPython.cc
+++ b/data/python_bindings/DataPython.cc
@@ -558,7 +558,7 @@ void createTransformationsSubmodule(py::module_& dataset_submodule) {
   py::class_<FeatureEnhancementConfig,
              std::shared_ptr<FeatureEnhancementConfig>>(
       transformations_submodule, "NerFeatureConfig")
-      .def(py::init<bool, bool, bool, bool, bool, bool, bool>(),
+      .def(py::init<bool, bool, bool, bool, bool, bool, bool, bool>(),
            py::arg("names"), py::arg("location_features"),
            py::arg("organization_features"), py::arg("case_features"),
            py::arg("numerical_features"), py::arg("emails"),

--- a/data/python_bindings/DataPython.cc
+++ b/data/python_bindings/DataPython.cc
@@ -562,7 +562,7 @@ void createTransformationsSubmodule(py::module_& dataset_submodule) {
            py::arg("names"), py::arg("location_features"),
            py::arg("organization_features"), py::arg("case_features"),
            py::arg("numerical_features"), py::arg("emails"),
-           py::arg("phone_numbers"));
+           py::arg("phone_numbers"), py::arg("use_char_4_input_featurization"));
 
   py::class_<ner::NerLearnedTag, std::shared_ptr<ner::NerLearnedTag>>(
       transformations_submodule, "NERLearnedTag")

--- a/data/src/transformations/ner/NerDyadicDataProcessor.cc
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.cc
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <optional>
 #include <regex>
+#include <string>
 
 namespace thirdai::data {
 
@@ -263,16 +264,28 @@ std::string NerDyadicDataProcessor::generateDyadicWindows(
 
     for (size_t lower_index = interval_size > index ? 0 : index - interval_size;
          lower_index < index; lower_index++) {
-      prev_window.push_back(_dyadic_previous_prefix +
-                            std::to_string(interval_id) + "_" +
-                            tokens[lower_index]);
+      for (const auto& context_tokenizer : _context_tokenizers) {
+        auto toks = context_tokenizer->toStrings(tokens[lower_index]);
+        prev_window.reserve(prev_window.size() + toks.size());
+        for (const auto& tok : toks) {
+          prev_window.push_back(_dyadic_previous_prefix +
+                                std::to_string(interval_id) + "_" + tok);
+        }
+      }
     }
 
     for (size_t upper_index = std::min(
              index + interval_size, static_cast<uint32_t>(tokens.size() - 1));
          upper_index > index; upper_index--) {
-      next_window.push_back(_dyadic_next_prefix + std::to_string(interval_id) +
-                            "_" + tokens[upper_index]);
+
+      for (const auto& context_tokenizer : _context_tokenizers) {
+        auto toks = context_tokenizer->toStrings(tokens[upper_index]);
+        prev_window.reserve(prev_window.size() + toks.size());
+        for (const auto& tok : toks) {
+          prev_window.push_back(_dyadic_previous_prefix +
+                                std::to_string(interval_id) + "_" + tok);
+        }
+      }
     }
 
     dyadic_windows.push_back(prev_window);

--- a/data/src/transformations/ner/NerDyadicDataProcessor.cc
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.cc
@@ -262,7 +262,7 @@ std::string NerDyadicDataProcessor::generateDyadicWindows(
     prev_window.reserve(interval_size);
     next_window.reserve(interval_size);
 
-    if (_feature_enhancement_config.use_char_4_input_featurization) {
+    if (_feature_enhancement_config->use_char_4_input_featurization) {
       for (size_t lower_index = interval_size > index ? 0
                                                       : index - interval_size;
            lower_index < index; lower_index++) {

--- a/data/src/transformations/ner/NerDyadicDataProcessor.cc
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.cc
@@ -262,29 +262,47 @@ std::string NerDyadicDataProcessor::generateDyadicWindows(
     prev_window.reserve(interval_size);
     next_window.reserve(interval_size);
 
-    for (size_t lower_index = interval_size > index ? 0 : index - interval_size;
-         lower_index < index; lower_index++) {
-      for (const auto& context_tokenizer : _context_tokenizers) {
-        auto toks = context_tokenizer->toStrings(tokens[lower_index]);
-        prev_window.reserve(prev_window.size() + toks.size());
-        for (const auto& tok : toks) {
-          prev_window.push_back(_dyadic_previous_prefix +
-                                std::to_string(interval_id) + "_" + tok);
+    if (_feature_enhancement_config.use_char_4_input_featurization) {
+      for (size_t lower_index = interval_size > index ? 0
+                                                      : index - interval_size;
+           lower_index < index; lower_index++) {
+        for (const auto& context_tokenizer : _context_tokenizers) {
+          auto toks = context_tokenizer->toStrings(tokens[lower_index]);
+          prev_window.reserve(prev_window.size() + toks.size());
+          for (const auto& tok : toks) {
+            prev_window.push_back(_dyadic_previous_prefix +
+                                  std::to_string(interval_id) + "_" + tok);
+          }
         }
       }
-    }
 
-    for (size_t upper_index = std::min(
-             index + interval_size, static_cast<uint32_t>(tokens.size() - 1));
-         upper_index > index; upper_index--) {
-
-      for (const auto& context_tokenizer : _context_tokenizers) {
-        auto toks = context_tokenizer->toStrings(tokens[upper_index]);
-        prev_window.reserve(prev_window.size() + toks.size());
-        for (const auto& tok : toks) {
-          prev_window.push_back(_dyadic_previous_prefix +
-                                std::to_string(interval_id) + "_" + tok);
+      for (size_t upper_index = std::min(
+               index + interval_size, static_cast<uint32_t>(tokens.size() - 1));
+           upper_index > index; upper_index--) {
+        for (const auto& context_tokenizer : _context_tokenizers) {
+          auto toks = context_tokenizer->toStrings(tokens[upper_index]);
+          next_window.reserve(next_window.size() + toks.size());
+          for (const auto& tok : toks) {
+            next_window.push_back(_dyadic_previous_prefix +
+                                  std::to_string(interval_id) + "_" + tok);
+          }
         }
+      }
+    } else {
+      for (size_t lower_index = interval_size > index ? 0
+                                                      : index - interval_size;
+           lower_index < index; lower_index++) {
+        prev_window.push_back(_dyadic_previous_prefix +
+                              std::to_string(interval_id) + "_" +
+                              tokens[lower_index]);
+      }
+
+      for (size_t upper_index = std::min(
+               index + interval_size, static_cast<uint32_t>(tokens.size() - 1));
+           upper_index > index; upper_index--) {
+        next_window.push_back(_dyadic_next_prefix +
+                              std::to_string(interval_id) + "_" +
+                              tokens[upper_index]);
       }
     }
 

--- a/data/src/transformations/ner/NerDyadicDataProcessor.h
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.h
@@ -144,8 +144,8 @@ class NerDyadicDataProcessor
   bool _for_inference;
 
   std::string _target_prefix = "t_";
-  std::string _dyadic_previous_prefix = "p_";
-  std::string _dyadic_next_prefix = "p_";
+  std::string _dyadic_previous_prefix = "pp_";
+  std::string _dyadic_next_prefix = "np_";
 
   std::vector<dataset::TextTokenizerPtr> _context_tokenizers = {
       dataset::CharKGramTokenizer::make(4),

--- a/data/src/transformations/ner/NerDyadicDataProcessor.h
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.h
@@ -137,8 +137,12 @@ class NerDyadicDataProcessor
   bool _for_inference;
 
   std::string _target_prefix = "t_";
-  std::string _dyadic_previous_prefix = "pp_";
-  std::string _dyadic_next_prefix = "np_";
+  std::string _dyadic_previous_prefix = "p_";
+  std::string _dyadic_next_prefix = "p_";
+
+  std::vector<dataset::TextTokenizerPtr> _context_tokenizers = {
+      dataset::CharKGramTokenizer::make(4),
+      dataset::NaiveSplitTokenizer::make()};
 };
 
 }  // namespace thirdai::data

--- a/data/src/transformations/ner/NerDyadicDataProcessor.h
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.h
@@ -21,6 +21,7 @@ struct FeatureEnhancementConfig {
   bool enhance_numerical_features = true;
   bool find_emails = true;
   bool find_phonenumbers = true;
+  bool use_char_4_input_featurization = false;
 
   std::unordered_set<std::string> location_keywords = {
       "lives", "live", "lived", "located", "moved", "near", "adjacent"};
@@ -54,14 +55,16 @@ struct FeatureEnhancementConfig {
                            bool enhance_organization_features,
                            bool enhance_case_features,
                            bool enhance_numerical_features, bool find_emails,
-                           bool find_phonenumbers)
+                           bool find_phonenumbers,
+                           bool use_char_4_input_featurization)
       : enhance_names(enhance_names),
         enhance_location_features(enhance_location_features),
         enhance_organization_features(enhance_organization_features),
         enhance_case_features(enhance_case_features),
         enhance_numerical_features(enhance_numerical_features),
         find_emails(find_emails),
-        find_phonenumbers(find_phonenumbers) {}
+        find_phonenumbers(find_phonenumbers),
+        use_char_4_input_featurization(use_char_4_input_featurization) {}
 
   explicit FeatureEnhancementConfig(const ar::Archive& archive) {
     enhance_names = archive.getOr<bool>("enhance_names", true);
@@ -74,6 +77,8 @@ struct FeatureEnhancementConfig {
         archive.getOr<bool>("enhance_numerical_features", true);
     find_emails = archive.getOr<bool>("find_emails", true);
     find_phonenumbers = archive.getOr<bool>("find_phonenumbers", true);
+    use_char_4_input_featurization =
+        archive.getOr<bool>("use_char_4_input_featurization", false);
   }
 
   ar::ConstArchivePtr toArchive() const {
@@ -88,6 +93,8 @@ struct FeatureEnhancementConfig {
              ar::boolean(enhance_numerical_features));
     map->set("find_emails", ar::boolean(find_emails));
     map->set("find_phonenumbers", ar::boolean(find_phonenumbers));
+    map->set("use_char_4_input_featurization",
+             ar::boolean(use_char_4_input_featurization));
     return map;
   }
 };


### PR DESCRIPTION
```py
import thirdai

tokens_column = "source"
tags_column = "target"

TAG_MAP = {"O": 0, "NAME": 1}
target_word_tokenizers = [
    thirdai.dataset.CharKGramTokenizer(4),
    thirdai.dataset.NaiveSplitTokenizer(" "),
]

from thirdai import data

dyadic_num_intervals = 3
ner_transformation = data.transformations.NerTokenizerUnigram(
    tokens_column="source",
    featurized_sentence_column="featurized_sentence",
    target_column="target",
    target_dim=len(TAG_MAP),
    dyadic_num_intervals=3,
    target_word_tokenizers=target_word_tokenizers,
    feature_enhancement_config=None,
    tag_to_label=TAG_MAP,
)

tokens = "Pratik is me".split()
ner_transformation.process_token(tokens, 1)

# prints
't_is t_is p_0_Prat p_0_rati p_0_atik p_0_Pratik p_0_me p_0_me p_1_Prat p_1_rati p_1_atik p_1_Pratik p_1_me p_1_me p_2_Prat p_2_rati p_2_atik p_2_Pratik p_2_me p_2_me  2_ALPHA 0_DIGIT 0_PUNCT'
```