### PR TITLE
fix wheel building actions

### DIFF
--- a/.github/workflows/build_linux_x86_64_wheels.yml
+++ b/.github/workflows/build_linux_x86_64_wheels.yml
@@ -96,7 +96,7 @@ jobs:
 
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
       

--- a/.github/workflows/build_macos_x86_wheels.yml
+++ b/.github/workflows/build_macos_x86_wheels.yml
@@ -87,7 +87,7 @@ jobs:
 
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
       

--- a/.github/workflows/build_maxos_arm64_wheels.yml
+++ b/.github/workflows/build_maxos_arm64_wheels.yml
@@ -72,7 +72,7 @@ jobs:
 
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
       

--- a/.github/workflows/build_windows_wheels.yml
+++ b/.github/workflows/build_windows_wheels.yml
@@ -90,7 +90,7 @@ jobs:
 
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
       


### PR DESCRIPTION
All wheel building actions recently fail with this error:

```Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/```

On this branch the action doesn't fail immediately but will continue running until success:
https://github.com/ThirdAILabs/Universe/actions/runs/10774072223/job/29875282539