### PR TITLE
tokenize clean_tokens

### DIFF
--- a/data/src/transformations/ner/NerDyadicDataProcessor.cc
+++ b/data/src/transformations/ner/NerDyadicDataProcessor.cc
@@ -220,7 +220,11 @@ std::string NerDyadicDataProcessor::processToken(
   // TODO(@shubh3ai) : make the dropout ratio configurable
   if (_for_inference || rand() % 2 == 0) {
     for (const auto& tokenizer : _target_word_tokenizers) {
-      auto tokens = tokenizer->toStrings(lower_cased_tokens[index]);
+      // to change the target token tokenization, change the first argument of
+      // toStrings here. example, if you want to remove punct from target token,
+      // call the remove punct func and pass the value here
+      auto tokens =
+          tokenizer->toStrings(ner::utils::trimPunctuation(target_token));
       tokenized_target_token.reserve(tokenized_target_token.size() +
                                      tokens.size());
       tokenized_target_token.insert(tokenized_target_token.end(),
@@ -237,7 +241,9 @@ std::string NerDyadicDataProcessor::processToken(
     repr += _target_prefix + tok + " ";
   }
 
-  repr += generateDyadicWindows(tokens, index);
+  // to use lower cased tokenization for the context or any other modifications,
+  // change the first argument to the function here
+  repr += generateDyadicWindows(lower_cased_tokens, index);
 
   if (_feature_enhancement_config.has_value()) {
     repr += " " + getExtraFeatures(tokens, index, lower_cased_tokens);


### PR DESCRIPTION
```py
tokens = "My name is Shubh.".split()
ner_transformation.process_token(tokens, 3)

# t_shub t_hubh t_shubh pp_0_is pp_1_name pp_1_is pp_2_My 
# pp_2_name pp_2_is   IS_CAPS_LOCK PREVIOUS_LOWER CONTAINS_NAMED_WORDS  5_ALPHA 0_DIGIT 1_PUNCT'
```

Earlier, target word would be `Shubh.` and tokenized as `t_Shub t_hubh t_Shubh. t_ubh.`. 

This can help with dealing with flakiness and reduce the reliance of the model on casing or exact matches.


Another experiment could be remove all the punctuations from the target token but retain the casing while tokenizing.